### PR TITLE
Add demographics

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
         AnalysisConfiguration("county", "location_raw", "county_coded", CodeSchemes.KENYA_COUNTY),
         kenya_mapper.export_kenya_counties_map,
         f"{automated_analysis_output_dir}/maps/counties/county_",
-        export_by_theme=True  # TODO pipeline_configuration.automated_analysis.generate_county_theme_distribution_maps
+        export_by_theme=True
     )
 
     log.info(f"Exporting participation maps for each Kenya constituency...")
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         AnalysisConfiguration("constituency", "location_raw", "constituency_coded", CodeSchemes.KENYA_CONSTITUENCY),
         kenya_mapper.export_kenya_constituencies_map,
         f"{automated_analysis_output_dir}/maps/constituencies/constituency_",
-        export_by_theme=True  # TODO pipeline_configuration.automated_analysis.generate_constituency_theme_distribution_maps
+        export_by_theme=True
     )
 
     log.info("Automated analysis python script complete")

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -3,6 +3,7 @@ import csv
 from collections import OrderedDict
 import sys
 
+from core_data_modules.analysis.mapping import participation_maps, kenya_mapper
 from core_data_modules.cleaners import Codes
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data.io import TracedDataJsonIO
@@ -10,6 +11,7 @@ from core_data_modules.util import IOUtils
 from core_data_modules.analysis import AnalysisConfiguration, engagement_counts, theme_distributions, \
     repeat_participations, sample_messages, traffic_analysis, analysis_utils
 
+from configurations.code_schemes import CodeSchemes
 from src.lib import PipelineConfiguration
 
 log = Logger(__name__)
@@ -89,78 +91,6 @@ if __name__ == "__main__":
             f
         )
 
-    log.info(f'Computing repeat and new participation per show ...')
-    # Computes the number of new and repeat consented individuals who participated in each radio show.
-    # Repeat participants are consented individuals who participated in previous shows prior to the target show.
-    # New participants are consented individuals who participated in target show but din't participate in previous shows.
-    repeat_new_participation_map = OrderedDict()  # of rqa_raw_field to participation metrics.
-
-    rqa_raw_fields =  [plan.raw_field for plan in PipelineConfiguration.RQA_CODING_PLANS]
-
-    #TODO: update to use responded() once moved to core
-    for rqa_raw_field in rqa_raw_fields:
-        target_radio_show = rqa_raw_field  # radio show in which we are calculating repeat and new participation metrics for.
-
-        target_radio_show_participants = set()  # contains uids of individuals who participated in target radio show.
-        for ind in individuals:
-            if ind["consent_withdrawn"] == Codes.TRUE:
-                continue
-
-            if target_radio_show in ind:
-                target_radio_show_participants.add(ind['uid'])
-
-        previous_radio_shows = []  # rqa_raw_fields of shows that aired before the target radio show.
-        for rqa_raw_field in rqa_raw_fields:
-            if rqa_raw_field == target_radio_show:
-                break
-
-            previous_radio_shows.append(rqa_raw_field)
-
-        previous_radio_shows_participants = set()  # uids of individuals who participated in previous radio shows.
-        for rqa_raw_field in previous_radio_shows:
-            for ind in individuals:
-                if ind["consent_withdrawn"] == Codes.TRUE:
-                    continue
-
-                if rqa_raw_field in ind:
-                    previous_radio_shows_participants.add(ind['uid'])
-
-        # Check for uids of individuals who participated in target and previous shows.
-        repeat_participants = target_radio_show_participants.intersection(previous_radio_shows_participants)
-
-        # Check for uids of individuals who participated in target show but din't participate in previous shows.
-        new_participants = target_radio_show_participants.difference(previous_radio_shows_participants)
-
-        repeat_new_participation_map[target_radio_show] = {
-            "Radio Show": target_radio_show,  # Todo switch to dataset name
-            "No. of opt-in participants": len(target_radio_show_participants),
-            "No. of opt-in participants that are new": len(new_participants),
-            "No. of opt-in participants that are repeats": len(repeat_participants),
-            "% of opt-in participants that are new": None,
-            "% of opt-in participants that are repeats": None
-        }
-
-        # Compute:
-        #  -% of opt-in participants that are new, by computing No. of opt-in participants that are new / No. of opt-in participants
-        #  * 100, to 1 decimal place.
-        #  - % of opt-in participants that are repeats, by computing No. of opt-in participants that are repeats / No. of opt-in participants
-        #  * 100, to 1 decimal place.
-        if len(new_participants) > 0:
-            repeat_new_participation_map[target_radio_show]["% of opt-in participants that are new"] = \
-                round(len(new_participants) / len(target_radio_show_participants) * 100, 1)
-            repeat_new_participation_map[target_radio_show]["% of opt-in participants that are repeats"] = \
-                round(len(repeat_participants) / len(target_radio_show_participants) * 100, 1)
-
-    with open(f"{automated_analysis_output_dir}/per_show_repeat_and_new_participation.csv", "w") as f:
-        headers = ["Radio Show", "No. of opt-in participants", "No. of opt-in participants that are new",
-                   "No. of opt-in participants that are repeats", "% of opt-in participants that are new",
-                   "% of opt-in participants that are repeats"]
-        writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
-        writer.writeheader()
-
-        for row in repeat_new_participation_map.values():
-            writer.writerow(row)
-
     log.info("Computing demographic distributions...")
     with open(f"{automated_analysis_output_dir}/demographic_distributions.csv", "w") as f:
         theme_distributions.export_theme_distributions_csv(
@@ -199,5 +129,25 @@ if __name__ == "__main__":
                 pipeline_configuration.automated_analysis.traffic_labels,
                 f
             )
+
+    log.info(f"Exporting participation maps for each Kenya county...")
+    participation_maps.export_participation_maps(
+        individuals, CONSENT_WITHDRAWN_KEY,
+        coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
+        AnalysisConfiguration("county", "location_raw", "county_coded", CodeSchemes.KENYA_COUNTY),
+        kenya_mapper.export_kenya_counties_map,
+        f"{automated_analysis_output_dir}/maps/counties/county_",
+        export_by_theme=True  # TODO pipeline_configuration.automated_analysis.generate_county_theme_distribution_maps
+    )
+
+    log.info(f"Exporting participation maps for each Kenya constituency...")
+    participation_maps.export_participation_maps(
+        individuals, CONSENT_WITHDRAWN_KEY,
+        coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
+        AnalysisConfiguration("constituency", "location_raw", "constituency_coded", CodeSchemes.KENYA_CONSTITUENCY),
+        kenya_mapper.export_kenya_constituencies_map,
+        f"{automated_analysis_output_dir}/maps/constituencies/constituency_",
+        export_by_theme=True  # TODO pipeline_configuration.automated_analysis.generate_constituency_theme_distribution_maps
+    )
 
     log.info("Automated analysis python script complete")

--- a/code_schemes/age.json
+++ b/code_schemes/age.json
@@ -1,0 +1,1141 @@
+{
+  "SchemeID": "Scheme-4189e74c",
+  "Name": "Age",
+  "Version": "0.0.0.4",
+  "Codes": [
+    {
+      "CodeID": "code-a3305435",
+      "CodeType": "Normal",
+      "DisplayText": "10",
+      "NumericValue": 10,
+      "StringValue": "10",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "10"
+      ]
+    },
+    {
+      "CodeID": "code-da61caa4",
+      "CodeType": "Normal",
+      "DisplayText": "11",
+      "NumericValue": 11,
+      "StringValue": "11",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "11"
+      ]
+    },
+    {
+      "CodeID": "code-48fca137",
+      "CodeType": "Normal",
+      "DisplayText": "12",
+      "NumericValue": 12,
+      "StringValue": "12",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "12"
+      ]
+    },
+    {
+      "CodeID": "code-3fe12b55",
+      "CodeType": "Normal",
+      "DisplayText": "13",
+      "NumericValue": 13,
+      "StringValue": "13",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "13"
+      ]
+    },
+    {
+      "CodeID": "code-a800738e",
+      "CodeType": "Normal",
+      "DisplayText": "14",
+      "NumericValue": 14,
+      "StringValue": "14",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "14"
+      ]
+    },
+    {
+      "CodeID": "code-3974fd97",
+      "CodeType": "Normal",
+      "DisplayText": "15",
+      "NumericValue": 15,
+      "StringValue": "15",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "15"
+      ]
+    },
+    {
+      "CodeID": "code-dfb81fb8",
+      "CodeType": "Normal",
+      "DisplayText": "16",
+      "NumericValue": 16,
+      "StringValue": "16",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "16"
+      ]
+    },
+    {
+      "CodeID": "code-ba009721",
+      "CodeType": "Normal",
+      "DisplayText": "17",
+      "NumericValue": 17,
+      "StringValue": "17",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "17"
+      ]
+    },
+    {
+      "CodeID": "code-1c301f52",
+      "CodeType": "Normal",
+      "DisplayText": "18",
+      "NumericValue": 18,
+      "StringValue": "18",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "18"
+      ]
+    },
+    {
+      "CodeID": "code-611f7707",
+      "CodeType": "Normal",
+      "DisplayText": "19",
+      "NumericValue": 19,
+      "StringValue": "19",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "19"
+      ]
+    },
+    {
+      "CodeID": "code-86085ec1",
+      "CodeType": "Normal",
+      "DisplayText": "20",
+      "NumericValue": 20,
+      "StringValue": "20",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "20"
+      ]
+    },
+    {
+      "CodeID": "code-99612198",
+      "CodeType": "Normal",
+      "DisplayText": "21",
+      "NumericValue": 21,
+      "StringValue": "21",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "21"
+      ]
+    },
+    {
+      "CodeID": "code-21138648",
+      "CodeType": "Normal",
+      "DisplayText": "22",
+      "NumericValue": 22,
+      "StringValue": "22",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "22"
+      ]
+    },
+    {
+      "CodeID": "code-96c4c617",
+      "CodeType": "Normal",
+      "DisplayText": "23",
+      "NumericValue": 23,
+      "StringValue": "23",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "23"
+      ]
+    },
+    {
+      "CodeID": "code-c38728ac",
+      "CodeType": "Normal",
+      "DisplayText": "24",
+      "NumericValue": 24,
+      "StringValue": "24",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "24"
+      ]
+    },
+    {
+      "CodeID": "code-47558a0f",
+      "CodeType": "Normal",
+      "DisplayText": "25",
+      "NumericValue": 25,
+      "StringValue": "25",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "25"
+      ]
+    },
+    {
+      "CodeID": "code-b2d12ec2",
+      "CodeType": "Normal",
+      "DisplayText": "26",
+      "NumericValue": 26,
+      "StringValue": "26",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "26"
+      ]
+    },
+    {
+      "CodeID": "code-1a81268e",
+      "CodeType": "Normal",
+      "DisplayText": "27",
+      "NumericValue": 27,
+      "StringValue": "27",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "27"
+      ]
+    },
+    {
+      "CodeID": "code-b8f4f830",
+      "CodeType": "Normal",
+      "DisplayText": "28",
+      "NumericValue": 28,
+      "StringValue": "28",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "28"
+      ]
+    },
+    {
+      "CodeID": "code-64c0bc1e",
+      "CodeType": "Normal",
+      "DisplayText": "29",
+      "NumericValue": 29,
+      "StringValue": "29",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "29"
+      ]
+    },
+    {
+      "CodeID": "code-65107395",
+      "CodeType": "Normal",
+      "DisplayText": "30",
+      "NumericValue": 30,
+      "StringValue": "30",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "30"
+      ]
+    },
+    {
+      "CodeID": "code-8684db85",
+      "CodeType": "Normal",
+      "DisplayText": "31",
+      "NumericValue": 31,
+      "StringValue": "31",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "31"
+      ]
+    },
+    {
+      "CodeID": "code-15100f11",
+      "CodeType": "Normal",
+      "DisplayText": "32",
+      "NumericValue": 32,
+      "StringValue": "32",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "32"
+      ]
+    },
+    {
+      "CodeID": "code-e505941c",
+      "CodeType": "Normal",
+      "DisplayText": "33",
+      "NumericValue": 33,
+      "StringValue": "33",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "33"
+      ]
+    },
+    {
+      "CodeID": "code-758f33ca",
+      "CodeType": "Normal",
+      "DisplayText": "34",
+      "NumericValue": 34,
+      "StringValue": "34",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "34"
+      ]
+    },
+    {
+      "CodeID": "code-47411ccc",
+      "CodeType": "Normal",
+      "DisplayText": "35",
+      "NumericValue": 35,
+      "StringValue": "35",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "35"
+      ]
+    },
+    {
+      "CodeID": "code-91212abb",
+      "CodeType": "Normal",
+      "DisplayText": "36",
+      "NumericValue": 36,
+      "StringValue": "36",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "36"
+      ]
+    },
+    {
+      "CodeID": "code-9ca299d3",
+      "CodeType": "Normal",
+      "DisplayText": "37",
+      "NumericValue": 37,
+      "StringValue": "37",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "37"
+      ]
+    },
+    {
+      "CodeID": "code-3af3f3bc",
+      "CodeType": "Normal",
+      "DisplayText": "38",
+      "NumericValue": 38,
+      "StringValue": "38",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "38"
+      ]
+    },
+    {
+      "CodeID": "code-a3ffb8eb",
+      "CodeType": "Normal",
+      "DisplayText": "39",
+      "NumericValue": 39,
+      "StringValue": "39",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "39"
+      ]
+    },
+    {
+      "CodeID": "code-43536bdb",
+      "CodeType": "Normal",
+      "DisplayText": "40",
+      "NumericValue": 40,
+      "StringValue": "40",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "40"
+      ]
+    },
+    {
+      "CodeID": "code-8c3a380a",
+      "CodeType": "Normal",
+      "DisplayText": "41",
+      "NumericValue": 41,
+      "StringValue": "41",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "41"
+      ]
+    },
+    {
+      "CodeID": "code-582a8f6b",
+      "CodeType": "Normal",
+      "DisplayText": "42",
+      "NumericValue": 42,
+      "StringValue": "42",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "42"
+      ]
+    },
+    {
+      "CodeID": "code-67a69d7e",
+      "CodeType": "Normal",
+      "DisplayText": "43",
+      "NumericValue": 43,
+      "StringValue": "43",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "43"
+      ]
+    },
+    {
+      "CodeID": "code-155ce717",
+      "CodeType": "Normal",
+      "DisplayText": "44",
+      "NumericValue": 44,
+      "StringValue": "44",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "44"
+      ]
+    },
+    {
+      "CodeID": "code-8c03003d",
+      "CodeType": "Normal",
+      "DisplayText": "45",
+      "NumericValue": 45,
+      "StringValue": "45",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "45"
+      ]
+    },
+    {
+      "CodeID": "code-d137606e",
+      "CodeType": "Normal",
+      "DisplayText": "46",
+      "NumericValue": 46,
+      "StringValue": "46",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "46"
+      ]
+    },
+    {
+      "CodeID": "code-acb6ec83",
+      "CodeType": "Normal",
+      "DisplayText": "47",
+      "NumericValue": 47,
+      "StringValue": "47",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "47"
+      ]
+    },
+    {
+      "CodeID": "code-d43b4984",
+      "CodeType": "Normal",
+      "DisplayText": "48",
+      "NumericValue": 48,
+      "StringValue": "48",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "48"
+      ]
+    },
+    {
+      "CodeID": "code-83f41b8a",
+      "CodeType": "Normal",
+      "DisplayText": "49",
+      "NumericValue": 49,
+      "StringValue": "49",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "49"
+      ]
+    },
+    {
+      "CodeID": "code-78ee8e09",
+      "CodeType": "Normal",
+      "DisplayText": "50",
+      "NumericValue": 50,
+      "StringValue": "50",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "50"
+      ]
+    },
+    {
+      "CodeID": "code-d2de461a",
+      "CodeType": "Normal",
+      "DisplayText": "51",
+      "NumericValue": 51,
+      "StringValue": "51",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "51"
+      ]
+    },
+    {
+      "CodeID": "code-69e9ba61",
+      "CodeType": "Normal",
+      "DisplayText": "52",
+      "NumericValue": 52,
+      "StringValue": "52",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "52"
+      ]
+    },
+    {
+      "CodeID": "code-410c8b0b",
+      "CodeType": "Normal",
+      "DisplayText": "53",
+      "NumericValue": 53,
+      "StringValue": "53",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "53"
+      ]
+    },
+    {
+      "CodeID": "code-153ba3ca",
+      "CodeType": "Normal",
+      "DisplayText": "54",
+      "NumericValue": 54,
+      "StringValue": "54",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "54"
+      ]
+    },
+    {
+      "CodeID": "code-a058d8b7",
+      "CodeType": "Normal",
+      "DisplayText": "55",
+      "NumericValue": 55,
+      "StringValue": "55",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "55"
+      ]
+    },
+    {
+      "CodeID": "code-dfacc203",
+      "CodeType": "Normal",
+      "DisplayText": "56",
+      "NumericValue": 56,
+      "StringValue": "56",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "56"
+      ]
+    },
+    {
+      "CodeID": "code-6aeda7b0",
+      "CodeType": "Normal",
+      "DisplayText": "57",
+      "NumericValue": 57,
+      "StringValue": "57",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "57"
+      ]
+    },
+    {
+      "CodeID": "code-dce4076b",
+      "CodeType": "Normal",
+      "DisplayText": "58",
+      "NumericValue": 58,
+      "StringValue": "58",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "58"
+      ]
+    },
+    {
+      "CodeID": "code-bf2545e6",
+      "CodeType": "Normal",
+      "DisplayText": "59",
+      "NumericValue": 59,
+      "StringValue": "59",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "59"
+      ]
+    },
+    {
+      "CodeID": "code-82b7f5da",
+      "CodeType": "Normal",
+      "DisplayText": "60",
+      "NumericValue": 60,
+      "StringValue": "60",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "60"
+      ]
+    },
+    {
+      "CodeID": "code-ff99c651",
+      "CodeType": "Normal",
+      "DisplayText": "61",
+      "NumericValue": 61,
+      "StringValue": "61",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "61"
+      ]
+    },
+    {
+      "CodeID": "code-d74ef454",
+      "CodeType": "Normal",
+      "DisplayText": "62",
+      "NumericValue": 62,
+      "StringValue": "62",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "62"
+      ]
+    },
+    {
+      "CodeID": "code-53534823",
+      "CodeType": "Normal",
+      "DisplayText": "63",
+      "NumericValue": 63,
+      "StringValue": "63",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "63"
+      ]
+    },
+    {
+      "CodeID": "code-b5f21247",
+      "CodeType": "Normal",
+      "DisplayText": "64",
+      "NumericValue": 64,
+      "StringValue": "64",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "64"
+      ]
+    },
+    {
+      "CodeID": "code-b2f491d4",
+      "CodeType": "Normal",
+      "DisplayText": "65",
+      "NumericValue": 65,
+      "StringValue": "65",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "65"
+      ]
+    },
+    {
+      "CodeID": "code-de5fbf60",
+      "CodeType": "Normal",
+      "DisplayText": "66",
+      "NumericValue": 66,
+      "StringValue": "66",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "66"
+      ]
+    },
+    {
+      "CodeID": "code-539f2239",
+      "CodeType": "Normal",
+      "DisplayText": "67",
+      "NumericValue": 67,
+      "StringValue": "67",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "67"
+      ]
+    },
+    {
+      "CodeID": "code-7b4d3a0e",
+      "CodeType": "Normal",
+      "DisplayText": "68",
+      "NumericValue": 68,
+      "StringValue": "68",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "68"
+      ]
+    },
+    {
+      "CodeID": "code-a42b0a69",
+      "CodeType": "Normal",
+      "DisplayText": "69",
+      "NumericValue": 69,
+      "StringValue": "69",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "69"
+      ]
+    },
+    {
+      "CodeID": "code-64c24042",
+      "CodeType": "Normal",
+      "DisplayText": "70",
+      "NumericValue": 70,
+      "StringValue": "70",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "70"
+      ]
+    },
+    {
+      "CodeID": "code-3cafd342",
+      "CodeType": "Normal",
+      "DisplayText": "71",
+      "NumericValue": 71,
+      "StringValue": "71",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "71"
+      ]
+    },
+    {
+      "CodeID": "code-50672e04",
+      "CodeType": "Normal",
+      "DisplayText": "72",
+      "NumericValue": 72,
+      "StringValue": "72",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "72"
+      ]
+    },
+    {
+      "CodeID": "code-74878f0b",
+      "CodeType": "Normal",
+      "DisplayText": "73",
+      "NumericValue": 73,
+      "StringValue": "73",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "73"
+      ]
+    },
+    {
+      "CodeID": "code-dd1cf2d2",
+      "CodeType": "Normal",
+      "DisplayText": "74",
+      "NumericValue": 74,
+      "StringValue": "74",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "74"
+      ]
+    },
+    {
+      "CodeID": "code-f8a7e88f",
+      "CodeType": "Normal",
+      "DisplayText": "75",
+      "NumericValue": 75,
+      "StringValue": "75",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "75"
+      ]
+    },
+    {
+      "CodeID": "code-a7d16804",
+      "CodeType": "Normal",
+      "DisplayText": "76",
+      "NumericValue": 76,
+      "StringValue": "76",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "76"
+      ]
+    },
+    {
+      "CodeID": "code-41835b91",
+      "CodeType": "Normal",
+      "DisplayText": "77",
+      "NumericValue": 77,
+      "StringValue": "77",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "77"
+      ]
+    },
+    {
+      "CodeID": "code-0684d296",
+      "CodeType": "Normal",
+      "DisplayText": "78",
+      "NumericValue": 78,
+      "StringValue": "78",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "78"
+      ]
+    },
+    {
+      "CodeID": "code-f602771d",
+      "CodeType": "Normal",
+      "DisplayText": "79",
+      "NumericValue": 79,
+      "StringValue": "79",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "79"
+      ]
+    },
+    {
+      "CodeID": "code-578e10c9",
+      "CodeType": "Normal",
+      "DisplayText": "80",
+      "NumericValue": 80,
+      "StringValue": "80",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "80"
+      ]
+    },
+    {
+      "CodeID": "code-f38f5850",
+      "CodeType": "Normal",
+      "DisplayText": "81",
+      "NumericValue": 81,
+      "StringValue": "81",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "81"
+      ]
+    },
+    {
+      "CodeID": "code-6e0c16d2",
+      "CodeType": "Normal",
+      "DisplayText": "82",
+      "NumericValue": 82,
+      "StringValue": "82",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "82"
+      ]
+    },
+    {
+      "CodeID": "code-02553fdc",
+      "CodeType": "Normal",
+      "DisplayText": "83",
+      "NumericValue": 83,
+      "StringValue": "83",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "83"
+      ]
+    },
+    {
+      "CodeID": "code-a586776d",
+      "CodeType": "Normal",
+      "DisplayText": "84",
+      "NumericValue": 84,
+      "StringValue": "84",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "84"
+      ]
+    },
+    {
+      "CodeID": "code-017bf47a",
+      "CodeType": "Normal",
+      "DisplayText": "85",
+      "NumericValue": 85,
+      "StringValue": "85",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "85"
+      ]
+    },
+    {
+      "CodeID": "code-ee52b0b0",
+      "CodeType": "Normal",
+      "DisplayText": "86",
+      "NumericValue": 86,
+      "StringValue": "86",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "86"
+      ]
+    },
+    {
+      "CodeID": "code-6d7d3595",
+      "CodeType": "Normal",
+      "DisplayText": "87",
+      "NumericValue": 87,
+      "StringValue": "87",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "87"
+      ]
+    },
+    {
+      "CodeID": "code-be368793",
+      "CodeType": "Normal",
+      "DisplayText": "88",
+      "NumericValue": 88,
+      "StringValue": "88",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "88"
+      ]
+    },
+    {
+      "CodeID": "code-a23c339b",
+      "CodeType": "Normal",
+      "DisplayText": "89",
+      "NumericValue": 89,
+      "StringValue": "89",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "89"
+      ]
+    },
+    {
+      "CodeID": "code-40cb634b",
+      "CodeType": "Normal",
+      "DisplayText": "90",
+      "NumericValue": 90,
+      "StringValue": "90",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "90"
+      ]
+    },
+    {
+      "CodeID": "code-37fd292b",
+      "CodeType": "Normal",
+      "DisplayText": "91",
+      "NumericValue": 91,
+      "StringValue": "91",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "91"
+      ]
+    },
+    {
+      "CodeID": "code-799f6908",
+      "CodeType": "Normal",
+      "DisplayText": "92",
+      "NumericValue": 92,
+      "StringValue": "92",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "92"
+      ]
+    },
+    {
+      "CodeID": "code-01c71faf",
+      "CodeType": "Normal",
+      "DisplayText": "93",
+      "NumericValue": 93,
+      "StringValue": "93",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "93"
+      ]
+    },
+    {
+      "CodeID": "code-e8ed1956",
+      "CodeType": "Normal",
+      "DisplayText": "94",
+      "NumericValue": 94,
+      "StringValue": "94",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "94"
+      ]
+    },
+    {
+      "CodeID": "code-d4753bfa",
+      "CodeType": "Normal",
+      "DisplayText": "95",
+      "NumericValue": 95,
+      "StringValue": "95",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "95"
+      ]
+    },
+    {
+      "CodeID": "code-51ac3e78",
+      "CodeType": "Normal",
+      "DisplayText": "96",
+      "NumericValue": 96,
+      "StringValue": "96",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "96"
+      ]
+    },
+    {
+      "CodeID": "code-5c30d7bf",
+      "CodeType": "Normal",
+      "DisplayText": "97",
+      "NumericValue": 97,
+      "StringValue": "97",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "97"
+      ]
+    },
+    {
+      "CodeID": "code-7bc64328",
+      "CodeType": "Normal",
+      "DisplayText": "98",
+      "NumericValue": 98,
+      "StringValue": "98",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "98"
+      ]
+    },
+    {
+      "CodeID": "code-36856c7f",
+      "CodeType": "Normal",
+      "DisplayText": "99",
+      "NumericValue": 99,
+      "StringValue": "99",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "99"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/age.json
+++ b/code_schemes/age.json
@@ -4,6 +4,16 @@
   "Version": "0.0.0.4",
   "Codes": [
     {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
       "CodeID": "code-a3305435",
       "CodeType": "Normal",
       "DisplayText": "10",

--- a/code_schemes/age_category.json
+++ b/code_schemes/age_category.json
@@ -1,0 +1,216 @@
+{
+  "SchemeID": "Scheme-eea1ce89",
+  "Name": "Age Category",
+  "Version": "0.0.0.1",
+  "Codes": [
+     {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-aa2640e7",
+      "CodeType": "Normal",
+      "DisplayText": "10 to 14",
+      "NumericValue": 1,
+      "StringValue": "10_to_14",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "10 to 14"
+      ]
+    },
+    {
+      "CodeID": "code-57391e8f",
+      "CodeType": "Normal",
+      "DisplayText": "15 to 17",
+      "NumericValue": 2,
+      "StringValue": "15_to_17",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "15 to 17"
+      ]
+    },
+    {
+      "CodeID": "code-ef3c9330",
+      "CodeType": "Normal",
+      "DisplayText": "18 to 35",
+      "NumericValue": 3,
+      "StringValue": "18_to_35",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "18 to 35"
+      ]
+    },
+    {
+      "CodeID": "code-494d7659",
+      "CodeType": "Normal",
+      "DisplayText": "36 to 54",
+      "NumericValue": 4,
+      "StringValue": "36_to_54",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "36 to 54"
+      ]
+    },
+    {
+      "CodeID": "code-968879ef",
+      "CodeType": "Normal",
+      "DisplayText": "55 to 99",
+      "NumericValue": 5,
+      "StringValue": "55_to_99",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "55 to 99"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/age_category.json
+++ b/code_schemes/age_category.json
@@ -3,7 +3,7 @@
   "Name": "Age Category",
   "Version": "0.0.0.1",
   "Codes": [
-     {
+    {
       "CodeID": "code-E-720cdb66",
       "CodeType": "Meta",
       "MetaCode": "escalate",

--- a/code_schemes/disabled.json
+++ b/code_schemes/disabled.json
@@ -1,0 +1,222 @@
+{
+  "SchemeID": "Scheme-6e456bff",
+  "Name": "Disabled",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-eb714938",
+      "CodeType": "Normal",
+      "DisplayText": "yes",
+      "NumericValue": 1,
+      "StringValue": "yes",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-975d6dca",
+      "CodeType": "Normal",
+      "DisplayText": "no",
+      "NumericValue": 2,
+      "StringValue": "no",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "StringValue": "impact",
+      "NumericValue": -100140,
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/code_schemes/gender.json
+++ b/code_schemes/gender.json
@@ -1,0 +1,230 @@
+{
+  "SchemeID": "Scheme-12cb6f95",
+  "Name": "Gender",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-63dcde9a",
+      "CodeType": "Normal",
+      "DisplayText": "man",
+      "NumericValue": 1,
+      "StringValue": "man",
+      "Shortcut": "m",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "male"
+      ]
+    },
+    {
+      "CodeID": "code-86a4602c",
+      "CodeType": "Normal",
+      "DisplayText": "woman",
+      "NumericValue": 2,
+      "StringValue" : "woman",
+      "Shortcut": "f",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "female"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+     {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "StringValue": "impact",
+      "NumericValue": -100140,
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/code_schemes/kenya_constituency.json
+++ b/code_schemes/kenya_constituency.json
@@ -1,0 +1,3377 @@
+{
+  "SchemeID": "Scheme-4c5b955d",
+  "Name": "Kenya Constituency",
+  "Version": "0.0.0.3",
+  "Codes": [
+    {
+      "CodeID": "code-b8bbb7e8",
+      "DisplayText": "ainabkoi",
+      "CodeType": "Normal",
+      "NumericValue": 295,
+      "StringValue": "ainabkoi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ainabkoi"
+      ]
+    },
+    {
+      "CodeID": "code-b65ddac5",
+      "DisplayText": "ainamoi",
+      "CodeType": "Normal",
+      "NumericValue": 148,
+      "StringValue": "ainamoi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ainamoi"
+      ]
+    },
+    {
+      "CodeID": "code-c7cd5c53",
+      "DisplayText": "aldai",
+      "CodeType": "Normal",
+      "NumericValue": 157,
+      "StringValue": "aldai",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "aldai"
+      ]
+    },
+    {
+      "CodeID": "code-16b55d8a",
+      "DisplayText": "alego usonga",
+      "CodeType": "Normal",
+      "NumericValue": 237,
+      "StringValue": "alego_usonga",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "alego usonga"
+      ]
+    },
+    {
+      "CodeID": "code-634b15bc",
+      "DisplayText": "awendo",
+      "CodeType": "Normal",
+      "NumericValue": 257,
+      "StringValue": "awendo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "awendo"
+      ]
+    },
+    {
+      "CodeID": "code-7f686207",
+      "DisplayText": "bahati",
+      "CodeType": "Normal",
+      "NumericValue": 179,
+      "StringValue": "bahati",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bahati"
+      ]
+    },
+    {
+      "CodeID": "code-dae428b9",
+      "DisplayText": "balambala",
+      "CodeType": "Normal",
+      "NumericValue": 48,
+      "StringValue": "balambala",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "balambala"
+      ]
+    },
+    {
+      "CodeID": "code-e577f67b",
+      "DisplayText": "banissa",
+      "CodeType": "Normal",
+      "NumericValue": 60,
+      "StringValue": "banissa",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "banissa"
+      ]
+    },
+    {
+      "CodeID": "code-5de15741",
+      "DisplayText": "baringo central",
+      "CodeType": "Normal",
+      "NumericValue": 164,
+      "StringValue": "baringo_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "baringo central"
+      ]
+    },
+    {
+      "CodeID": "code-39bcb625",
+      "DisplayText": "baringo north",
+      "CodeType": "Normal",
+      "NumericValue": 163,
+      "StringValue": "baringo_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "baringo north"
+      ]
+    },
+    {
+      "CodeID": "code-5619fa09",
+      "DisplayText": "baringo south",
+      "CodeType": "Normal",
+      "NumericValue": 165,
+      "StringValue": "baringo_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "baringo south"
+      ]
+    },
+    {
+      "CodeID": "code-afd75890",
+      "DisplayText": "belgut",
+      "CodeType": "Normal",
+      "NumericValue": 196,
+      "StringValue": "belgut",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "belgut"
+      ]
+    },
+    {
+      "CodeID": "code-39257ea9",
+      "DisplayText": "bobasi",
+      "CodeType": "Normal",
+      "NumericValue": 267,
+      "StringValue": "bobasi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bobasi"
+      ]
+    },
+    {
+      "CodeID": "code-452feaa9",
+      "DisplayText": "bomachoge borabu",
+      "CodeType": "Normal",
+      "NumericValue": 266,
+      "StringValue": "bomachoge_borabu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bomachoge borabu"
+      ]
+    },
+    {
+      "CodeID": "code-da15ffe8",
+      "DisplayText": "bomachoge chache",
+      "CodeType": "Normal",
+      "NumericValue": 268,
+      "StringValue": "bomachoge_chache",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bomachoge chache"
+      ]
+    },
+    {
+      "CodeID": "code-2ef4c4a8",
+      "DisplayText": "bomet central",
+      "CodeType": "Normal",
+      "NumericValue": 200,
+      "StringValue": "bomet_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bomet central"
+      ]
+    },
+    {
+      "CodeID": "code-d598886e",
+      "DisplayText": "bomet east",
+      "CodeType": "Normal",
+      "NumericValue": 199,
+      "StringValue": "bomet_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bomet east"
+      ]
+    },
+    {
+      "CodeID": "code-ce931cb7",
+      "DisplayText": "bonchari",
+      "CodeType": "Normal",
+      "NumericValue": 264,
+      "StringValue": "bonchari",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bonchari"
+      ]
+    },
+    {
+      "CodeID": "code-a438eb0e",
+      "DisplayText": "bondo",
+      "CodeType": "Normal",
+      "NumericValue": 239,
+      "StringValue": "bondo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bondo"
+      ]
+    },
+    {
+      "CodeID": "code-629f2d43",
+      "DisplayText": "borabu",
+      "CodeType": "Normal",
+      "NumericValue": 276,
+      "StringValue": "borabu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "borabu"
+      ]
+    },
+    {
+      "CodeID": "code-6c64b98d",
+      "DisplayText": "budalangi",
+      "CodeType": "Normal",
+      "NumericValue": 225,
+      "StringValue": "budalangi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "budalangi"
+      ]
+    },
+    {
+      "CodeID": "code-1aff845e",
+      "DisplayText": "bumula",
+      "CodeType": "Normal",
+      "NumericValue": 229,
+      "StringValue": "bumula",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bumula"
+      ]
+    },
+    {
+      "CodeID": "code-0e1f8588",
+      "DisplayText": "bura",
+      "CodeType": "Normal",
+      "NumericValue": 40,
+      "StringValue": "bura",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bura"
+      ]
+    },
+    {
+      "CodeID": "code-aac6af97",
+      "DisplayText": "bureti",
+      "CodeType": "Normal",
+      "NumericValue": 195,
+      "StringValue": "bureti",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bureti"
+      ]
+    },
+    {
+      "CodeID": "code-e7edf6f7",
+      "DisplayText": "butere",
+      "CodeType": "Normal",
+      "NumericValue": 210,
+      "StringValue": "butere",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "butere"
+      ]
+    },
+    {
+      "CodeID": "code-aaff9f31",
+      "DisplayText": "butula",
+      "CodeType": "Normal",
+      "NumericValue": 223,
+      "StringValue": "butula",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "butula"
+      ]
+    },
+    {
+      "CodeID": "code-1fc6f566",
+      "DisplayText": "buuri",
+      "CodeType": "Normal",
+      "NumericValue": 77,
+      "StringValue": "buuri",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "buuri"
+      ]
+    },
+    {
+      "CodeID": "code-8d9bf52e",
+      "DisplayText": "central imenti",
+      "CodeType": "Normal",
+      "NumericValue": 78,
+      "StringValue": "central_imenti",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "central imenti"
+      ]
+    },
+    {
+      "CodeID": "code-2c6ae3a3",
+      "DisplayText": "changamwe",
+      "CodeType": "Normal",
+      "NumericValue": 21,
+      "StringValue": "changamwe",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "changamwe"
+      ]
+    },
+    {
+      "CodeID": "code-d73c5b34",
+      "DisplayText": "chepalungu",
+      "CodeType": "Normal",
+      "NumericValue": 198,
+      "StringValue": "chepalungu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "chepalungu"
+      ]
+    },
+    {
+      "CodeID": "code-2aabb1fa",
+      "DisplayText": "cherangany",
+      "CodeType": "Normal",
+      "NumericValue": 143,
+      "StringValue": "cherangany",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "cherangany"
+      ]
+    },
+    {
+      "CodeID": "code-5076bdd4",
+      "DisplayText": "chesumei",
+      "CodeType": "Normal",
+      "NumericValue": 159,
+      "StringValue": "chesumei",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "chesumei"
+      ]
+    },
+    {
+      "CodeID": "code-24c85d6f",
+      "DisplayText": "dadaab",
+      "CodeType": "Normal",
+      "NumericValue": 50,
+      "StringValue": "dadaab",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dadaab"
+      ]
+    },
+    {
+      "CodeID": "code-deb1348d",
+      "DisplayText": "dagoretti north",
+      "CodeType": "Normal",
+      "NumericValue": 278,
+      "StringValue": "dagoretti_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dagoretti north"
+      ]
+    },
+    {
+      "CodeID": "code-8719fc72",
+      "DisplayText": "dagoretti south",
+      "CodeType": "Normal",
+      "NumericValue": 279,
+      "StringValue": "dagoretti_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dagoretti south"
+      ]
+    },
+    {
+      "CodeID": "code-95586ee2",
+      "DisplayText": "eldama ravine",
+      "CodeType": "Normal",
+      "NumericValue": 167,
+      "StringValue": "eldama_ravine",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eldama ravine"
+      ]
+    },
+    {
+      "CodeID": "code-3e8f00af",
+      "DisplayText": "eldas",
+      "CodeType": "Normal",
+      "NumericValue": 58,
+      "StringValue": "eldas",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eldas"
+      ]
+    },
+    {
+      "CodeID": "code-801fa4fe",
+      "DisplayText": "embakasi central",
+      "CodeType": "Normal",
+      "NumericValue": 287,
+      "StringValue": "embakasi_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "embakasi central"
+      ]
+    },
+    {
+      "CodeID": "code-d6fe5239",
+      "DisplayText": "embakasi east",
+      "CodeType": "Normal",
+      "NumericValue": 288,
+      "StringValue": "embakasi_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "embakasi east"
+      ]
+    },
+    {
+      "CodeID": "code-b12d9bbe",
+      "DisplayText": "embakasi north",
+      "CodeType": "Normal",
+      "NumericValue": 286,
+      "StringValue": "embakasi_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "embakasi north"
+      ]
+    },
+    {
+      "CodeID": "code-e70276f2",
+      "DisplayText": "embakasi south",
+      "CodeType": "Normal",
+      "NumericValue": 285,
+      "StringValue": "embakasi_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "embakasi south"
+      ]
+    },
+    {
+      "CodeID": "code-733155a9",
+      "DisplayText": "embakasi west",
+      "CodeType": "Normal",
+      "NumericValue": 289,
+      "StringValue": "embakasi_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "embakasi west"
+      ]
+    },
+    {
+      "CodeID": "code-332c1d09",
+      "DisplayText": "emgwen",
+      "CodeType": "Normal",
+      "NumericValue": 160,
+      "StringValue": "emgwen",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "emgwen"
+      ]
+    },
+    {
+      "CodeID": "code-daaccdee",
+      "DisplayText": "emuhaya",
+      "CodeType": "Normal",
+      "NumericValue": 218,
+      "StringValue": "emuhaya",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "emuhaya"
+      ]
+    },
+    {
+      "CodeID": "code-6b9cbb5a",
+      "DisplayText": "emurua dikirr",
+      "CodeType": "Normal",
+      "NumericValue": 183,
+      "StringValue": "emurua_dikirr",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "emurua dikirr"
+      ]
+    },
+    {
+      "CodeID": "code-0f1538e4",
+      "DisplayText": "endebess",
+      "CodeType": "Normal",
+      "NumericValue": 140,
+      "StringValue": "endebess",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "endebess"
+      ]
+    },
+    {
+      "CodeID": "code-69b38d93",
+      "DisplayText": "fafi",
+      "CodeType": "Normal",
+      "NumericValue": 51,
+      "StringValue": "fafi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "fafi"
+      ]
+    },
+    {
+      "CodeID": "code-561b207f",
+      "DisplayText": "funyula",
+      "CodeType": "Normal",
+      "NumericValue": 224,
+      "StringValue": "funyula",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "funyula"
+      ]
+    },
+    {
+      "CodeID": "code-7c1f94af",
+      "DisplayText": "galole",
+      "CodeType": "Normal",
+      "NumericValue": 39,
+      "StringValue": "galole",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "galole"
+      ]
+    },
+    {
+      "CodeID": "code-be75ecec",
+      "DisplayText": "ganze",
+      "CodeType": "Normal",
+      "NumericValue": 35,
+      "StringValue": "ganze",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ganze"
+      ]
+    },
+    {
+      "CodeID": "code-23b4f587",
+      "DisplayText": "garissa township",
+      "CodeType": "Normal",
+      "NumericValue": 47,
+      "StringValue": "garissa_township",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "garissa township"
+      ]
+    },
+    {
+      "CodeID": "code-6483b422",
+      "DisplayText": "garsen",
+      "CodeType": "Normal",
+      "NumericValue": 38,
+      "StringValue": "garsen",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "garsen"
+      ]
+    },
+    {
+      "CodeID": "code-85b8dad4",
+      "DisplayText": "gatanga",
+      "CodeType": "Normal",
+      "NumericValue": 14,
+      "StringValue": "gatanga",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gatanga"
+      ]
+    },
+    {
+      "CodeID": "code-42d7a240",
+      "DisplayText": "gatundu north",
+      "CodeType": "Normal",
+      "NumericValue": 115,
+      "StringValue": "gatundu_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gatundu north"
+      ]
+    },
+    {
+      "CodeID": "code-598d589e",
+      "DisplayText": "gatundu south",
+      "CodeType": "Normal",
+      "NumericValue": 114,
+      "StringValue": "gatundu_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gatundu south"
+      ]
+    },
+    {
+      "CodeID": "code-ea080d4a",
+      "DisplayText": "gem",
+      "CodeType": "Normal",
+      "NumericValue": 238,
+      "StringValue": "gem",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gem"
+      ]
+    },
+    {
+      "CodeID": "code-4e32405d",
+      "DisplayText": "gichugu",
+      "CodeType": "Normal",
+      "NumericValue": 1,
+      "StringValue": "gichugu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gichugu"
+      ]
+    },
+    {
+      "CodeID": "code-a6f085f5",
+      "DisplayText": "gilgil",
+      "CodeType": "Normal",
+      "NumericValue": 174,
+      "StringValue": "gilgil",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gilgil"
+      ]
+    },
+    {
+      "CodeID": "code-e11e669f",
+      "DisplayText": "githunguri",
+      "CodeType": "Normal",
+      "NumericValue": 119,
+      "StringValue": "githunguri",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "githunguri"
+      ]
+    },
+    {
+      "CodeID": "code-028fe818",
+      "DisplayText": "hamisi",
+      "CodeType": "Normal",
+      "NumericValue": 216,
+      "StringValue": "hamisi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "hamisi"
+      ]
+    },
+    {
+      "CodeID": "code-37d1954a",
+      "DisplayText": "homa bay town",
+      "CodeType": "Normal",
+      "NumericValue": 252,
+      "StringValue": "homa_bay_town",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "homa bay town"
+      ]
+    },
+    {
+      "CodeID": "code-c7b961c9",
+      "DisplayText": "igambang'ombe",
+      "CodeType": "Normal",
+      "NumericValue": 81,
+      "StringValue": "igambang_ombe",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "igambang'ombe"
+      ]
+    },
+    {
+      "CodeID": "code-3e97a5e5",
+      "DisplayText": "igembe_central",
+      "CodeType": "Normal",
+      "NumericValue": 72,
+      "StringValue": "igembe_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "igembe central"
+      ]
+    },
+    {
+      "CodeID": "code-a80fa660",
+      "DisplayText": "igembe north",
+      "CodeType": "Normal",
+      "NumericValue": 73,
+      "StringValue": "igembe_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "igembe north"
+      ]
+    },
+    {
+      "CodeID": "code-9fe810cc",
+      "DisplayText": "igembe south",
+      "CodeType": "Normal",
+      "NumericValue": 71,
+      "StringValue": "igembe_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "igembe south"
+      ]
+    },
+    {
+      "CodeID": "code-4c6d2954",
+      "DisplayText": "ijara",
+      "CodeType": "Normal",
+      "NumericValue": 52,
+      "StringValue": "ijara",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ijara"
+      ]
+    },
+    {
+      "CodeID": "code-8b195658",
+      "DisplayText": "ikolomani",
+      "CodeType": "Normal",
+      "NumericValue": 213,
+      "StringValue": "ikolomani",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ikolomani"
+      ]
+    },
+    {
+      "CodeID": "code-48d7d140",
+      "DisplayText": "isiolo north",
+      "CodeType": "Normal",
+      "NumericValue": 69,
+      "StringValue": "isiolo_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "isiolo north"
+      ]
+    },
+    {
+      "CodeID": "code-76ee1407",
+      "DisplayText": "isiolo south",
+      "CodeType": "Normal",
+      "NumericValue": 70,
+      "StringValue": "isiolo_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "isiolo south"
+      ]
+    },
+    {
+      "CodeID": "code-e4b3091f",
+      "DisplayText": "jomvu",
+      "CodeType": "Normal",
+      "NumericValue": 22,
+      "StringValue": "jomvu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "jomvu"
+      ]
+    },
+    {
+      "CodeID": "code-82d3521d",
+      "DisplayText": "juja",
+      "CodeType": "Normal",
+      "NumericValue": 116,
+      "StringValue": "juja",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "juja"
+      ]
+    },
+    {
+      "CodeID": "code-fbeb0563",
+      "DisplayText": "kabete",
+      "CodeType": "Normal",
+      "NumericValue": 122,
+      "StringValue": "kabete",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kabete"
+      ]
+    },
+    {
+      "CodeID": "code-8e3ab4c4",
+      "DisplayText": "kabondo kasipul",
+      "CodeType": "Normal",
+      "NumericValue": 249,
+      "StringValue": "kabondo_kasipul",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kabondo kasipul"
+      ]
+    },
+    {
+      "CodeID": "code-ac213faa",
+      "DisplayText": "kabuchai",
+      "CodeType": "Normal",
+      "NumericValue": 228,
+      "StringValue": "kabuchai",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kabuchai"
+      ]
+    },
+    {
+      "CodeID": "code-bc8c594b",
+      "DisplayText": "kacheliba",
+      "CodeType": "Normal",
+      "NumericValue": 134,
+      "StringValue": "kacheliba",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kacheliba"
+      ]
+    },
+    {
+      "CodeID": "code-31d4e00d",
+      "DisplayText": "kiambaa",
+      "CodeType": "Normal",
+      "NumericValue": 121,
+      "StringValue": "kiambaa",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kiambaa"
+      ]
+    },
+    {
+      "CodeID": "code-bd25a773",
+      "DisplayText": "kaiti",
+      "CodeType": "Normal",
+      "NumericValue": 105,
+      "StringValue": "kaiti",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kaiti"
+      ]
+    },
+    {
+      "CodeID": "code-d771657a",
+      "DisplayText": "kajiado central",
+      "CodeType": "Normal",
+      "NumericValue": 189,
+      "StringValue": "kajiado_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kajiado central"
+      ]
+    },
+    {
+      "CodeID": "code-3dd8d208",
+      "DisplayText": "kajiado east",
+      "CodeType": "Normal",
+      "NumericValue": 192,
+      "StringValue": "kajiado_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kajiado east"
+      ]
+    },
+    {
+      "CodeID": "code-4ce957aa",
+      "DisplayText": "kajiado north",
+      "CodeType": "Normal",
+      "NumericValue": 188,
+      "StringValue": "kajiado_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kajiado north"
+      ]
+    },
+    {
+      "CodeID": "code-ae933ace",
+      "DisplayText": "kajiado south",
+      "CodeType": "Normal",
+      "NumericValue": 191,
+      "StringValue": "kajiado_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kajiado south"
+      ]
+    },
+    {
+      "CodeID": "code-0f27ad5f",
+      "DisplayText": "kajiado west",
+      "CodeType": "Normal",
+      "NumericValue": 190,
+      "StringValue": "kajiado_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kajiado west"
+      ]
+    },
+    {
+      "CodeID": "code-6b2219a2",
+      "DisplayText": "kaloleni",
+      "CodeType": "Normal",
+      "NumericValue": 33,
+      "StringValue": "kaloleni",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kaloleni"
+      ]
+    },
+    {
+      "CodeID": "code-be535e6e",
+      "DisplayText": "kamukunji",
+      "CodeType": "Normal",
+      "NumericValue": 291,
+      "StringValue": "kamukunji",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kamukunji"
+      ]
+    },
+    {
+      "CodeID": "code-2cdc1368",
+      "DisplayText": "kandara",
+      "CodeType": "Normal",
+      "NumericValue": 9,
+      "StringValue": "kandara",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kandara"
+      ]
+    },
+    {
+      "CodeID": "code-1e893419",
+      "DisplayText": "kanduyi",
+      "CodeType": "Normal",
+      "NumericValue": 230,
+      "StringValue": "kanduyi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kanduyi"
+      ]
+    },
+    {
+      "CodeID": "code-287afcf3",
+      "DisplayText": "kangema",
+      "CodeType": "Normal",
+      "NumericValue": 10,
+      "StringValue": "kangema",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kangema"
+      ]
+    },
+    {
+      "CodeID": "code-11649af0",
+      "DisplayText": "kangundo",
+      "CodeType": "Normal",
+      "NumericValue": 97,
+      "StringValue": "kangundo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kangundo"
+      ]
+    },
+    {
+      "CodeID": "code-9e4f5d23",
+      "DisplayText": "kapenguria",
+      "CodeType": "Normal",
+      "NumericValue": 132,
+      "StringValue": "kapenguria",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kapenguria"
+      ]
+    },
+    {
+      "CodeID": "code-f13014a9",
+      "DisplayText": "kapseret",
+      "CodeType": "Normal",
+      "NumericValue": 149,
+      "StringValue": "kapseret",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kapseret"
+      ]
+    },
+    {
+      "CodeID": "code-5e84a39b",
+      "DisplayText": "karachuonyo",
+      "CodeType": "Normal",
+      "NumericValue": 250,
+      "StringValue": "karachuonyo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "karachuonyo"
+      ]
+    },
+    {
+      "CodeID": "code-c3a88872",
+      "DisplayText": "kasarani",
+      "CodeType": "Normal",
+      "NumericValue": 283,
+      "StringValue": "kasarani",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kasarani"
+      ]
+    },
+    {
+      "CodeID": "code-39fa4faa",
+      "DisplayText": "kasipul",
+      "CodeType": "Normal",
+      "NumericValue": 248,
+      "StringValue": "kasipul",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kasipul"
+      ]
+    },
+    {
+      "CodeID": "code-da0b5e11",
+      "DisplayText": "kathiani",
+      "CodeType": "Normal",
+      "NumericValue": 99,
+      "StringValue": "kathiani",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kathiani"
+      ]
+    },
+    {
+      "CodeID": "code-441fc6e5",
+      "DisplayText": "keiyo north",
+      "CodeType": "Normal",
+      "NumericValue": 154,
+      "StringValue": "keiyo_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "keiyo north"
+      ]
+    },
+    {
+      "CodeID": "code-a608e0a3",
+      "DisplayText": "keiyo south",
+      "CodeType": "Normal",
+      "NumericValue": 155,
+      "StringValue": "keiyo_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "keiyo south"
+      ]
+    },
+    {
+      "CodeID": "code-4c4b29e9",
+      "DisplayText": "kesses",
+      "CodeType": "Normal",
+      "NumericValue": 150,
+      "StringValue": "kesses",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kesses"
+      ]
+    },
+    {
+      "CodeID": "code-9e761ec2",
+      "DisplayText": "khwisero",
+      "CodeType": "Normal",
+      "NumericValue": 211,
+      "StringValue": "khwisero",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "khwisero"
+      ]
+    },
+    {
+      "CodeID": "code-8e788a16",
+      "DisplayText": "kiambu",
+      "CodeType": "Normal",
+      "NumericValue": 120,
+      "StringValue": "kiambu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kiambu"
+      ]
+    },
+    {
+      "CodeID": "code-71ec3ebc",
+      "DisplayText": "kibra",
+      "CodeType": "Normal",
+      "NumericValue": 281,
+      "StringValue": "kibra",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kibra"
+      ]
+    },
+    {
+      "CodeID": "code-3643a3d7",
+      "DisplayText": "kibwezi east",
+      "CodeType": "Normal",
+      "NumericValue": 108,
+      "StringValue": "kibwezi_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kibwezi east"
+      ]
+    },
+    {
+      "CodeID": "code-4b99eab7",
+      "DisplayText": "kibwezi west",
+      "CodeType": "Normal",
+      "NumericValue": 107,
+      "StringValue": "kibwezi_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kibwezi west"
+      ]
+    },
+    {
+      "CodeID": "code-3d99a19d",
+      "DisplayText": "kieni",
+      "CodeType": "Normal",
+      "NumericValue": 4,
+      "StringValue": "kieni",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kieni"
+      ]
+    },
+    {
+      "CodeID": "code-6dc55c8c",
+      "DisplayText": "kigumo",
+      "CodeType": "Normal",
+      "NumericValue": 11,
+      "StringValue": "kigumo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kigumo"
+      ]
+    },
+    {
+      "CodeID": "code-44ca0731",
+      "DisplayText": "kiharu",
+      "CodeType": "Normal",
+      "NumericValue": 12,
+      "StringValue": "kiharu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kiharu"
+      ]
+    },
+    {
+      "CodeID": "code-900d1d78",
+      "DisplayText": "kikuyu",
+      "CodeType": "Normal",
+      "NumericValue": 123,
+      "StringValue": "kikuyu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kikuyu"
+      ]
+    },
+    {
+      "CodeID": "code-a919b5a4",
+      "DisplayText": "kilgoris",
+      "CodeType": "Normal",
+      "NumericValue": 182,
+      "StringValue": "kilgoris",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kilgoris"
+      ]
+    },
+    {
+      "CodeID": "code-3c48cce0",
+      "DisplayText": "kilifi north",
+      "CodeType": "Normal",
+      "NumericValue": 31,
+      "StringValue": "kilifi_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kilifi north"
+      ]
+    },
+    {
+      "CodeID": "code-2d00ef36",
+      "DisplayText": "kilifi south",
+      "CodeType": "Normal",
+      "NumericValue": 32,
+      "StringValue": "kilifi_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kilifi south"
+      ]
+    },
+    {
+      "CodeID": "code-d03b039cs",
+      "DisplayText": "kilome",
+      "CodeType": "Normal",
+      "NumericValue": 104,
+      "StringValue": "kilome",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kilome"
+      ]
+    },
+    {
+      "CodeID": "code-816566d3",
+      "DisplayText": "kimilili",
+      "CodeType": "Normal",
+      "NumericValue": 233,
+      "StringValue": "kimilili",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kimilili"
+      ]
+    },
+    {
+      "CodeID": "code-6d71f392",
+      "DisplayText": "kiminini",
+      "CodeType": "Normal",
+      "NumericValue": 142,
+      "StringValue": "kiminini",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kiminini"
+      ]
+    },
+    {
+      "CodeID": "code-7bc43e11",
+      "DisplayText": "kinango",
+      "CodeType": "Normal",
+      "NumericValue": 30,
+      "StringValue": "kinango",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kinango"
+      ]
+    },
+    {
+      "CodeID": "code-2f62e27d",
+      "DisplayText": "kinangop",
+      "CodeType": "Normal",
+      "NumericValue": 109,
+      "StringValue": "kinangop",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kinangop"
+      ]
+    },
+    {
+      "CodeID": "code-0aed6ac4",
+      "DisplayText": "kipipiri",
+      "CodeType": "Normal",
+      "NumericValue": 110,
+      "StringValue": "kipipiri",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kipipiri"
+      ]
+    },
+    {
+      "CodeID": "code-841ca505",
+      "DisplayText": "kipkelion east",
+      "CodeType": "Normal",
+      "NumericValue": 193,
+      "StringValue": "kipkelion_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kipkelion east"
+      ]
+    },
+    {
+      "CodeID": "code-95148e2d",
+      "DisplayText": "kipkelion west",
+      "CodeType": "Normal",
+      "NumericValue": 194,
+      "StringValue": "kipkelion_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kipkelion west"
+      ]
+    },
+    {
+      "CodeID": "code-f87f26e6",
+      "DisplayText": "kirinyaga central",
+      "CodeType": "Normal",
+      "NumericValue": 15,
+      "StringValue": "kirinyaga_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kirinyaga central"
+      ]
+    },
+    {
+      "CodeID": "code-394ee616",
+      "DisplayText": "kisauni",
+      "CodeType": "Normal",
+      "NumericValue": 23,
+      "StringValue": "kisauni",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kisauni"
+      ]
+    },
+    {
+      "CodeID": "code-ad359afd",
+      "DisplayText": "kisumu central",
+      "CodeType": "Normal",
+      "NumericValue": 243,
+      "StringValue": "kisumu_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kisumu central"
+      ]
+    },
+    {
+      "CodeID": "code-79dfbbf2",
+      "DisplayText": "kisumu east",
+      "CodeType": "Normal",
+      "NumericValue": 241,
+      "StringValue": "kisumu_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kisumu east"
+      ]
+    },
+    {
+      "CodeID": "code-5e81b38c",
+      "DisplayText": "kisumu west",
+      "CodeType": "Normal",
+      "NumericValue": 242,
+      "StringValue": "kisumu_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kisumu west"
+      ]
+    },
+    {
+      "CodeID": "code-26e94d61",
+      "DisplayText": "kitui central",
+      "CodeType": "Normal",
+      "NumericValue": 92,
+      "StringValue": "kitui_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kitui central"
+      ]
+    },
+    {
+      "CodeID": "code-3b544621",
+      "DisplayText": "kitui east",
+      "CodeType": "Normal",
+      "NumericValue": 93,
+      "StringValue": "kitui_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kitui east"
+      ]
+    },
+    {
+      "CodeID": "code-c6bce2b7",
+      "DisplayText": "kitui rural",
+      "CodeType": "Normal",
+      "NumericValue": 91,
+      "StringValue": "kitui_rural",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kitui rural"
+      ]
+    },
+    {
+      "CodeID": "code-bffeef07",
+      "DisplayText": "kitui south",
+      "CodeType": "Normal",
+      "NumericValue": 94,
+      "StringValue": "kitui_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kitui south"
+      ]
+    },
+    {
+      "CodeID": "code-49177ef6",
+      "DisplayText": "kitui west",
+      "CodeType": "Normal",
+      "NumericValue": 90,
+      "StringValue": "kitui_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kitui west"
+      ]
+    },
+    {
+      "CodeID": "code-db61114a",
+      "DisplayText": "kitutu chache north",
+      "CodeType": "Normal",
+      "NumericValue": 271,
+      "StringValue": "kitutu_chache_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kitutu chache north"
+      ]
+    },
+    {
+      "CodeID": "code-f590228f",
+      "DisplayText": "kitutu chache south",
+      "CodeType": "Normal",
+      "NumericValue": 272,
+      "StringValue": "kitutu_chache_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kitutu chache south"
+      ]
+    },
+    {
+      "CodeID": "code-a7785432",
+      "DisplayText": "kitutu masaba",
+      "CodeType": "Normal",
+      "NumericValue": 273,
+      "StringValue": "kitutu_masaba",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kitutu masaba"
+      ]
+    },
+    {
+      "CodeID": "code-d40698d5",
+      "DisplayText": "konoin",
+      "CodeType": "Normal",
+      "NumericValue": 201,
+      "StringValue": "konoin",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "konoin"
+      ]
+    },
+    {
+      "CodeID": "code-afe2c992",
+      "DisplayText": "kuresoi north",
+      "CodeType": "Normal",
+      "NumericValue": 176,
+      "StringValue": "kuresoi_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kuresoi north"
+      ]
+    },
+    {
+      "CodeID": "code-db5b5032",
+      "DisplayText": "kuresoi south",
+      "CodeType": "Normal",
+      "NumericValue": 175,
+      "StringValue": "kuresoi_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kuresoi south"
+      ]
+    },
+    {
+      "CodeID": "code-ee7006bc",
+      "DisplayText": "kuria east",
+      "CodeType": "Normal",
+      "NumericValue": 263,
+      "StringValue": "kuria_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kuria east"
+      ]
+    },
+    {
+      "CodeID": "code-dfd05b20",
+      "DisplayText": "kuria west",
+      "CodeType": "Normal",
+      "NumericValue": 262,
+      "StringValue": "kuria_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kuria west"
+      ]
+    },
+    {
+      "CodeID": "code-c9ce99df",
+      "DisplayText": "kwanza",
+      "CodeType": "Normal",
+      "NumericValue": 139,
+      "StringValue": "kwanza",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kwanza"
+      ]
+    },
+    {
+      "CodeID": "code-3a3f84ff",
+      "DisplayText": "lafey",
+      "CodeType": "Normal",
+      "NumericValue": 64,
+      "StringValue": "lafey",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lafey"
+      ]
+    },
+    {
+      "CodeID": "code-72d1520b",
+      "DisplayText": "lagdera",
+      "CodeType": "Normal",
+      "NumericValue": 49,
+      "StringValue": "lagdera",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lagdera"
+      ]
+    },
+    {
+      "CodeID": "code-7a0e15bf",
+      "DisplayText": "laikipia east",
+      "CodeType": "Normal",
+      "NumericValue": 169,
+      "StringValue": "laikipia_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "laikipia east"
+      ]
+    },
+    {
+      "CodeID": "code-568baa29",
+      "DisplayText": "laikipia north",
+      "CodeType": "Normal",
+      "NumericValue": 170,
+      "StringValue": "laikipia_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "laikipia north"
+      ]
+    },
+    {
+      "CodeID": "code-4524ee60",
+      "DisplayText": "laikipia west",
+      "CodeType": "Normal",
+      "NumericValue": 168,
+      "StringValue": "laikipia_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "laikipia west"
+      ]
+    },
+    {
+      "CodeID": "code-59573e50",
+      "DisplayText": "laisamis",
+      "CodeType": "Normal",
+      "NumericValue": 68,
+      "StringValue": "laisamis",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "laisamis"
+      ]
+    },
+    {
+      "CodeID": "code-dcf1b585",
+      "DisplayText": "lamu east",
+      "CodeType": "Normal",
+      "NumericValue": 41,
+      "StringValue": "lamu_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lamu east"
+      ]
+    },
+    {
+      "CodeID": "code-174eda7b",
+      "DisplayText": "lamu west",
+      "CodeType": "Normal",
+      "NumericValue": 42,
+      "StringValue": "lamu_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lamu west"
+      ]
+    },
+    {
+      "CodeID": "code-d3f948bc",
+      "DisplayText": "lang'ata",
+      "CodeType": "Normal",
+      "NumericValue": 280,
+      "StringValue": "langata",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lang'ata"
+      ]
+    },
+    {
+      "CodeID": "code-3a3f9f2a",
+      "DisplayText": "lari",
+      "CodeType": "Normal",
+      "NumericValue": 125,
+      "StringValue": "lari",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lari"
+      ]
+    },
+    {
+      "CodeID": "code-f68e1c0a",
+      "DisplayText": "likoni",
+      "CodeType": "Normal",
+      "NumericValue": 25,
+      "StringValue": "likoni",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "likoni"
+      ]
+    },
+    {
+      "CodeID": "code-8d2a6562",
+      "DisplayText": "likuyani",
+      "CodeType": "Normal",
+      "NumericValue": 203,
+      "StringValue": "likuyani",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "likuyani"
+      ]
+    },
+    {
+      "CodeID": "code-5d0b4f1e",
+      "DisplayText": "limuru",
+      "CodeType": "Normal",
+      "NumericValue": 124,
+      "StringValue": "limuru",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "limuru"
+      ]
+    },
+    {
+      "CodeID": "code-e3d7ef7e",
+      "DisplayText": "loima",
+      "CodeType": "Normal",
+      "NumericValue": 129,
+      "StringValue": "loima",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "loima"
+      ]
+    },
+    {
+      "CodeID": "code-6dd450c5",
+      "DisplayText": "luanda",
+      "CodeType": "Normal",
+      "NumericValue": 217,
+      "StringValue": "luanda",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "luanda"
+      ]
+    },
+    {
+      "CodeID": "code-e494f6e9",
+      "DisplayText": "lugari",
+      "CodeType": "Normal",
+      "NumericValue": 202,
+      "StringValue": "lugari",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lugari"
+      ]
+    },
+    {
+      "CodeID": "code-18a4dc33",
+      "DisplayText": "lunga lunga",
+      "CodeType": "Normal",
+      "NumericValue": 28,
+      "StringValue": "lunga_lunga",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lunga lunga"
+      ]
+    },
+    {
+      "CodeID": "code-fdfbecbe",
+      "DisplayText": "lurambi",
+      "CodeType": "Normal",
+      "NumericValue": 205,
+      "StringValue": "lurambi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lurambi"
+      ]
+    },
+    {
+      "CodeID": "code-3ca8d0e4",
+      "DisplayText": "maara",
+      "CodeType": "Normal",
+      "NumericValue": 80,
+      "StringValue": "maara",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "maara"
+      ]
+    },
+    {
+      "CodeID": "code-b5831b88",
+      "DisplayText": "machakos town",
+      "CodeType": "Normal",
+      "NumericValue": 101,
+      "StringValue": "machakos_town",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "machakos town"
+      ]
+    },
+    {
+      "CodeID": "code-053fc1b7",
+      "DisplayText": "magarini",
+      "CodeType": "Normal",
+      "NumericValue": 37,
+      "StringValue": "magarini",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "magarini"
+      ]
+    },
+    {
+      "CodeID": "code-94447523",
+      "DisplayText": "makadara",
+      "CodeType": "Normal",
+      "NumericValue": 290,
+      "StringValue": "makadara",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "makadara"
+      ]
+    },
+    {
+      "CodeID": "code-beb3995e",
+      "DisplayText": "makueni",
+      "CodeType": "Normal",
+      "NumericValue": 106,
+      "StringValue": "makueni",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "makueni"
+      ]
+    },
+    {
+      "CodeID": "code-bbc733d2",
+      "DisplayText": "malava",
+      "CodeType": "Normal",
+      "NumericValue": 204,
+      "StringValue": "malava",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "malava"
+      ]
+    },
+    {
+      "CodeID": "code-74fbe177",
+      "DisplayText": "malindi",
+      "CodeType": "Normal",
+      "NumericValue": 36,
+      "StringValue": "malindi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "malindi"
+      ]
+    },
+    {
+      "CodeID": "code-c28fe27e",
+      "DisplayText": "mandera east",
+      "CodeType": "Normal",
+      "NumericValue": 63,
+      "StringValue": "mandera_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mandera east"
+      ]
+    },
+    {
+      "CodeID": "code-45637372",
+      "DisplayText": "mandera north",
+      "CodeType": "Normal",
+      "NumericValue": 61,
+      "StringValue": "mandera_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mandera north"
+      ]
+    },
+    {
+      "CodeID": "code-975bb5af",
+      "DisplayText": "mandera south",
+      "CodeType": "Normal",
+      "NumericValue": 62,
+      "StringValue": "mandera_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mandera south"
+      ]
+    },
+    {
+      "CodeID": "code-b91e4457",
+      "DisplayText": "mandera west",
+      "CodeType": "Normal",
+      "NumericValue": 59,
+      "StringValue": "mandera_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mandera west"
+      ]
+    },
+    {
+      "CodeID": "code-1dd6c06f",
+      "DisplayText": "manyatta",
+      "CodeType": "Normal",
+      "NumericValue": 83,
+      "StringValue": "manyatta",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "manyatta"
+      ]
+    },
+    {
+      "CodeID": "code-dc085902",
+      "DisplayText": "maragwa",
+      "CodeType": "Normal",
+      "NumericValue": 17,
+      "StringValue": "maragwa",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "maragwa"
+      ]
+    },
+    {
+      "CodeID": "code-8b713227",
+      "DisplayText": "marakwet east",
+      "CodeType": "Normal",
+      "NumericValue": 152,
+      "StringValue": "marakwet_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "marakwet east"
+      ]
+    },
+    {
+      "CodeID": "code-2080249d",
+      "DisplayText": "marakwet west",
+      "CodeType": "Normal",
+      "NumericValue": 153,
+      "StringValue": "marakwet_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "marakwet west"
+      ]
+    },
+    {
+      "CodeID": "code-cfaf3838",
+      "DisplayText": "masinga",
+      "CodeType": "Normal",
+      "NumericValue": 95,
+      "StringValue": "masinga",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "masinga"
+      ]
+    },
+    {
+      "CodeID": "code-e0b1f1a5",
+      "DisplayText": "matayos",
+      "CodeType": "Normal",
+      "NumericValue": 222,
+      "StringValue": "matayos",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "matayos"
+      ]
+    },
+    {
+      "CodeID": "code-5208e7d4",
+      "DisplayText": "mathare",
+      "CodeType": "Normal",
+      "NumericValue": 293,
+      "StringValue": "mathare",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mathare"
+      ]
+    },
+    {
+      "CodeID": "code-a9f738ca",
+      "DisplayText": "mathioya",
+      "CodeType": "Normal",
+      "NumericValue": 16,
+      "StringValue": "mathioya",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mathioya"
+      ]
+    },
+    {
+      "CodeID": "code-a54d1b36",
+      "DisplayText": "mathira",
+      "CodeType": "Normal",
+      "NumericValue": 5,
+      "StringValue": "mathira",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mathira"
+      ]
+    },
+    {
+      "CodeID": "code-27894f3d",
+      "DisplayText": "matuga",
+      "CodeType": "Normal",
+      "NumericValue": 29,
+      "StringValue": "matuga",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "matuga"
+      ]
+    },
+    {
+      "CodeID": "code-2a6711c1",
+      "DisplayText": "matungu",
+      "CodeType": "Normal",
+      "NumericValue": 209,
+      "StringValue": "matungu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "matungu"
+      ]
+    },
+    {
+      "CodeID": "code-aa1afeba",
+      "DisplayText": "matungulu",
+      "CodeType": "Normal",
+      "NumericValue": 98,
+      "StringValue": "matungulu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "matungulu"
+      ]
+    },
+    {
+      "CodeID": "code-5bff2b5f",
+      "DisplayText": "mavoko",
+      "CodeType": "Normal",
+      "NumericValue": 100,
+      "StringValue": "mavoko",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mavoko"
+      ]
+    },
+    {
+      "CodeID": "code-9d54a61d",
+      "DisplayText": "mbeere north",
+      "CodeType": "Normal",
+      "NumericValue": 86,
+      "StringValue": "mbeere_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mbeere north"
+      ]
+    },
+    {
+      "CodeID": "code-2aa560a7",
+      "DisplayText": "mbeere south",
+      "CodeType": "Normal",
+      "NumericValue": 85,
+      "StringValue": "mbeere_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mbeere south"
+      ]
+    },
+    {
+      "CodeID": "code-c24cb56f",
+      "DisplayText": "mbita",
+      "CodeType": "Normal",
+      "NumericValue": 254,
+      "StringValue": "mbita",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mbita"
+      ]
+    },
+    {
+      "CodeID": "code-b8c3ad10",
+      "DisplayText": "mbooni",
+      "CodeType": "Normal",
+      "NumericValue": 103,
+      "StringValue": "mbooni",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mbooni"
+      ]
+    },
+    {
+      "CodeID": "code-77f06d3f",
+      "DisplayText": "mogotio",
+      "CodeType": "Normal",
+      "NumericValue": 166,
+      "StringValue": "mogotio",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mogotio"
+      ]
+    },
+    {
+      "CodeID": "code-1f283c50",
+      "DisplayText": "moiben",
+      "CodeType": "Normal",
+      "NumericValue": 151,
+      "StringValue": "moiben",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "moiben"
+      ]
+    },
+    {
+      "CodeID": "code-04e85008",
+      "DisplayText": "molo",
+      "CodeType": "Normal",
+      "NumericValue": 171,
+      "StringValue": "molo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "molo"
+      ]
+    },
+    {
+      "CodeID": "code-db797b0f",
+      "DisplayText": "mosop",
+      "CodeType": "Normal",
+      "NumericValue": 161,
+      "StringValue": "mosop",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mosop"
+      ]
+    },
+    {
+      "CodeID": "code-648670c1",
+      "DisplayText": "moyale",
+      "CodeType": "Normal",
+      "NumericValue": 65,
+      "StringValue": "moyale",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "moyale"
+      ]
+    },
+    {
+      "CodeID": "code-d4004fa0",
+      "DisplayText": "msambweni",
+      "CodeType": "Normal",
+      "NumericValue": 27,
+      "StringValue": "msambweni",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "msambweni"
+      ]
+    },
+    {
+      "CodeID": "code-4549a160",
+      "DisplayText": "mt. elgon",
+      "CodeType": "Normal",
+      "NumericValue": 226,
+      "StringValue": "mt_elgon",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mt. elgon"
+      ]
+    },
+    {
+      "CodeID": "code-b5bdebbc",
+      "DisplayText": "muhoroni",
+      "CodeType": "Normal",
+      "NumericValue": 246,
+      "StringValue": "muhoroni",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "muhoroni"
+      ]
+    },
+    {
+      "CodeID": "code-2ee84b27",
+      "DisplayText": "mukurweini",
+      "CodeType": "Normal",
+      "NumericValue": 7,
+      "StringValue": "mukurweini",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mukurweini"
+      ]
+    },
+    {
+      "CodeID": "code-ef1d0d31",
+      "DisplayText": "mumias east",
+      "CodeType": "Normal",
+      "NumericValue": 208,
+      "StringValue": "mumias_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mumias east"
+      ]
+    },
+    {
+      "CodeID": "code-7f3ffcfd",
+      "DisplayText": "mumias west",
+      "CodeType": "Normal",
+      "NumericValue": 207,
+      "StringValue": "mumias_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mumias west"
+      ]
+    },
+    {
+      "CodeID": "code-1aefb8d1",
+      "DisplayText": "mvita",
+      "CodeType": "Normal",
+      "NumericValue": 26,
+      "StringValue": "mvita",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mvita"
+      ]
+    },
+    {
+      "CodeID": "code-460e0ac9",
+      "DisplayText": "mwala",
+      "CodeType": "Normal",
+      "NumericValue": 102,
+      "StringValue": "mwala",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mwala"
+      ]
+    },
+    {
+      "CodeID": "code-8f6e91a2",
+      "DisplayText": "mwatate",
+      "CodeType": "Normal",
+      "NumericValue": 45,
+      "StringValue": "mwatate",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mwatate"
+      ]
+    },
+    {
+      "CodeID": "code-bd610414",
+      "DisplayText": "mwea",
+      "CodeType": "Normal",
+      "NumericValue": 0,
+      "StringValue": "mwea",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mwea"
+      ]
+    },
+    {
+      "CodeID": "code-f441b769",
+      "DisplayText": "mwingi central",
+      "CodeType": "Normal",
+      "NumericValue": 89,
+      "StringValue": "mwingi_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mwingi central"
+      ]
+    },
+    {
+      "CodeID": "code-94916d69",
+      "DisplayText": "mwingi north",
+      "CodeType": "Normal",
+      "NumericValue": 87,
+      "StringValue": "mwingi_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mwingi north"
+      ]
+    },
+    {
+      "CodeID": "code-63cfa6c1",
+      "DisplayText": "mwingi west",
+      "CodeType": "Normal",
+      "NumericValue": 88,
+      "StringValue": "mwingi_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mwingi west"
+      ]
+    },
+    {
+      "CodeID": "code-b8e3753f",
+      "DisplayText": "naivasha",
+      "CodeType": "Normal",
+      "NumericValue": 173,
+      "StringValue": "naivasha",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "naivasha"
+      ]
+    },
+    {
+      "CodeID": "code-28570ab3",
+      "DisplayText": "nakuru town east",
+      "CodeType": "Normal",
+      "NumericValue": 181,
+      "StringValue": "nakuru_town_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nakuru town east"
+      ]
+    },
+    {
+      "CodeID": "code-2e48eef2",
+      "DisplayText": "nakuru town west",
+      "CodeType": "Normal",
+      "NumericValue": 180,
+      "StringValue": "nakuru_town_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nakuru town west"
+      ]
+    },
+    {
+      "CodeID": "code-6297f772",
+      "DisplayText": "nambale",
+      "CodeType": "Normal",
+      "NumericValue": 221,
+      "StringValue": "nambale",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nambale"
+      ]
+    },
+    {
+      "CodeID": "code-05f59b0e",
+      "DisplayText": "nandi hills",
+      "CodeType": "Normal",
+      "NumericValue": 158,
+      "StringValue": "nandi_hills",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nandi hills"
+      ]
+    },
+    {
+      "CodeID": "code-81b9f08e",
+      "DisplayText": "narok east",
+      "CodeType": "Normal",
+      "NumericValue": 185,
+      "StringValue": "narok_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "narok east"
+      ]
+    },
+    {
+      "CodeID": "code-a9940050",
+      "DisplayText": "narok north",
+      "CodeType": "Normal",
+      "NumericValue": 184,
+      "StringValue": "narok_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "narok north"
+      ]
+    },
+    {
+      "CodeID": "code-823791f9",
+      "DisplayText": "narok south",
+      "CodeType": "Normal",
+      "NumericValue": 186,
+      "StringValue": "narok_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "narok south"
+      ]
+    },
+    {
+      "CodeID": "code-817ca969",
+      "DisplayText": "narok west",
+      "CodeType": "Normal",
+      "NumericValue": 187,
+      "StringValue": "narok_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "narok west"
+      ]
+    },
+    {
+      "CodeID": "code-cc4f31e5",
+      "DisplayText": "navakholo",
+      "CodeType": "Normal",
+      "NumericValue": 206,
+      "StringValue": "navakholo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "navakholo"
+      ]
+    },
+    {
+      "CodeID": "code-d03189e0",
+      "DisplayText": "ndaragwa",
+      "CodeType": "Normal",
+      "NumericValue": 113,
+      "StringValue": "ndaragwa",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ndaragwa"
+      ]
+    },
+    {
+      "CodeID": "code-4983601a",
+      "DisplayText": "ndhiwa",
+      "CodeType": "Normal",
+      "NumericValue": 253,
+      "StringValue": "ndhiwa",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ndhiwa"
+      ]
+    },
+    {
+      "CodeID": "code-963ec546",
+      "DisplayText": "ndia",
+      "CodeType": "Normal",
+      "NumericValue": 2,
+      "StringValue": "ndia",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ndia"
+      ]
+    },
+    {
+      "CodeID": "code-db81185b",
+      "DisplayText": "njoro",
+      "CodeType": "Normal",
+      "NumericValue": 172,
+      "StringValue": "njoro",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "njoro"
+      ]
+    },
+    {
+      "CodeID": "code-147d212e",
+      "DisplayText": "north horr",
+      "CodeType": "Normal",
+      "NumericValue": 66,
+      "StringValue": "north_horr",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "north horr"
+      ]
+    },
+    {
+      "CodeID": "code-d0c9b724",
+      "DisplayText": "north imenti",
+      "CodeType": "Normal",
+      "NumericValue": 76,
+      "StringValue": "north_imenti",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "north imenti"
+      ]
+    },
+    {
+      "CodeID": "code-edd6ef38",
+      "DisplayText": "north mugirango",
+      "CodeType": "Normal",
+      "NumericValue": 275,
+      "StringValue": "north_mugirango",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "north mugirango"
+      ]
+    },
+    {
+      "CodeID": "code-3e3a3ba3",
+      "DisplayText": "nyakach",
+      "CodeType": "Normal",
+      "NumericValue": 247,
+      "StringValue": "nyakach",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyakach"
+      ]
+    },
+    {
+      "CodeID": "code-4f758675",
+      "DisplayText": "nyali",
+      "CodeType": "Normal",
+      "NumericValue": 24,
+      "StringValue": "nyali",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyali"
+      ]
+    },
+    {
+      "CodeID": "code-68369cec",
+      "DisplayText": "nyando",
+      "CodeType": "Normal",
+      "NumericValue": 245,
+      "StringValue": "nyando",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyando"
+      ]
+    },
+    {
+      "CodeID": "code-62f2c2a6",
+      "DisplayText": "nyaribari chache",
+      "CodeType": "Normal",
+      "NumericValue": 270,
+      "StringValue": "nyaribari_chache",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyaribari chache"
+      ]
+    },
+    {
+      "CodeID": "code-5a4492f2",
+      "DisplayText": "nyaribari masaba",
+      "CodeType": "Normal",
+      "NumericValue": 269,
+      "StringValue": "nyaribari_masaba",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyaribari masaba"
+      ]
+    },
+    {
+      "CodeID": "code-74643b6b",
+      "DisplayText": "nyatike",
+      "CodeType": "Normal",
+      "NumericValue": 261,
+      "StringValue": "nyatike",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyatike"
+      ]
+    },
+    {
+      "CodeID": "code-211b8756",
+      "DisplayText": "nyeri town",
+      "CodeType": "Normal",
+      "NumericValue": 8,
+      "StringValue": "nyeri_town",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyeri town"
+      ]
+    },
+    {
+      "CodeID": "code-4e89dae6",
+      "DisplayText": "ol_jorok",
+      "CodeType": "Normal",
+      "NumericValue": 112,
+      "StringValue": "ol_jorok",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ol jorok"
+      ]
+    },
+    {
+      "CodeID": "code-fd9d3681",
+      "DisplayText": "ol_kalou",
+      "CodeType": "Normal",
+      "NumericValue": 111,
+      "StringValue": "ol_kalou",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ol kalou"
+      ]
+    },
+    {
+      "CodeID": "code-5935a561",
+      "DisplayText": "othaya",
+      "CodeType": "Normal",
+      "NumericValue": 6,
+      "StringValue": "othaya",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "othaya"
+      ]
+    },
+    {
+      "CodeID": "code-a2e13401",
+      "DisplayText": "pokot south",
+      "CodeType": "Normal",
+      "NumericValue": 135,
+      "StringValue": "pokot_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "pokot south"
+      ]
+    },
+    {
+      "CodeID": "code-eced8470",
+      "DisplayText": "rabai",
+      "CodeType": "Normal",
+      "NumericValue": 34,
+      "StringValue": "rabai",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "rabai"
+      ]
+    },
+    {
+      "CodeID": "code-27cc7d52",
+      "DisplayText": "rangwe",
+      "CodeType": "Normal",
+      "NumericValue": 251,
+      "StringValue": "rangwe",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "rangwe"
+      ]
+    },
+    {
+      "CodeID": "code-b6ef8717",
+      "DisplayText": "rarieda",
+      "CodeType": "Normal",
+      "NumericValue": 240,
+      "StringValue": "rarieda",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "rarieda"
+      ]
+    },
+    {
+      "CodeID": "code-d811bdb9",
+      "DisplayText": "rongai",
+      "CodeType": "Normal",
+      "NumericValue": 178,
+      "StringValue": "rongai",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "rongai"
+      ]
+    },
+    {
+      "CodeID": "code-aed6b086",
+      "DisplayText": "rongo",
+      "CodeType": "Normal",
+      "NumericValue": 256,
+      "StringValue": "rongo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "rongo"
+      ]
+    },
+    {
+      "CodeID": "code-99817580",
+      "DisplayText": "roysambu",
+      "CodeType": "Normal",
+      "NumericValue": 282,
+      "StringValue": "roysambu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "roysambu"
+      ]
+    },
+    {
+      "CodeID": "code-d04a6a57",
+      "DisplayText": "ruaraka",
+      "CodeType": "Normal",
+      "NumericValue": 284,
+      "StringValue": "ruaraka",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ruaraka"
+      ]
+    },
+    {
+      "CodeID": "code-ad9d5763",
+      "DisplayText": "ruiru",
+      "CodeType": "Normal",
+      "NumericValue": 118,
+      "StringValue": "ruiru",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ruiru"
+      ]
+    },
+    {
+      "CodeID": "code-02604e81",
+      "DisplayText": "runyenjes",
+      "CodeType": "Normal",
+      "NumericValue": 84,
+      "StringValue": "runyenjes",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "runyenjes"
+      ]
+    },
+    {
+      "CodeID": "code-770de798",
+      "DisplayText": "sabatia",
+      "CodeType": "Normal",
+      "NumericValue": 215,
+      "StringValue": "sabatia",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "sabatia"
+      ]
+    },
+    {
+      "CodeID": "code-6e8ad492",
+      "DisplayText": "saboti",
+      "CodeType": "Normal",
+      "NumericValue": 141,
+      "StringValue": "saboti",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "saboti"
+      ]
+    },
+    {
+      "CodeID": "code-2a3f8aa0",
+      "DisplayText": "saku",
+      "CodeType": "Normal",
+      "NumericValue": 67,
+      "StringValue": "saku",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "saku"
+      ]
+    },
+    {
+      "CodeID": "code-7a5930b9",
+      "DisplayText": "samburu east",
+      "CodeType": "Normal",
+      "NumericValue": 138,
+      "StringValue": "samburu_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "samburu east"
+      ]
+    },
+    {
+      "CodeID": "code-6bd11945",
+      "DisplayText": "samburu north",
+      "CodeType": "Normal",
+      "NumericValue": 137,
+      "StringValue": "samburu_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "samburu north"
+      ]
+    },
+    {
+      "CodeID": "code-588f01cb",
+      "DisplayText": "samburu west",
+      "CodeType": "Normal",
+      "NumericValue": 136,
+      "StringValue": "samburu_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "samburu west"
+      ]
+    },
+    {
+      "CodeID": "code-0163b9eb",
+      "DisplayText": "seme",
+      "CodeType": "Normal",
+      "NumericValue": 244,
+      "StringValue": "seme",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "seme"
+      ]
+    },
+    {
+      "CodeID": "code-d36ebf00",
+      "DisplayText": "shinyalu",
+      "CodeType": "Normal",
+      "NumericValue": 212,
+      "StringValue": "shinyalu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "shinyalu"
+      ]
+    },
+    {
+      "CodeID": "code-9b381706",
+      "DisplayText": "sigor",
+      "CodeType": "Normal",
+      "NumericValue": 133,
+      "StringValue": "sigor",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "sigor"
+      ]
+    },
+    {
+      "CodeID": "code-d2710982",
+      "DisplayText": "sigowet/soin",
+      "CodeType": "Normal",
+      "NumericValue": 197,
+      "StringValue": "sigowet_soin",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "sigowet/soin"
+      ]
+    },
+    {
+      "CodeID": "code-36448577",
+      "DisplayText": "sirisia",
+      "CodeType": "Normal",
+      "NumericValue": 227,
+      "StringValue": "sirisia",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "sirisia"
+      ]
+    },
+    {
+      "CodeID": "code-ac044a9a",
+      "DisplayText": "sotik",
+      "CodeType": "Normal",
+      "NumericValue": 294,
+      "StringValue": "sotik",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "sotik"
+      ]
+    },
+    {
+      "CodeID": "code-94b77a31",
+      "DisplayText": "south imenti",
+      "CodeType": "Normal",
+      "NumericValue": 79,
+      "StringValue": "south_imenti",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "south imenti"
+      ]
+    },
+    {
+      "CodeID": "code-bf4f6b13",
+      "DisplayText": "south mugirango",
+      "CodeType": "Normal",
+      "NumericValue": 265,
+      "StringValue": "south_mugirango",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "south mugirango"
+      ]
+    },
+    {
+      "CodeID": "code-9400248f",
+      "DisplayText": "soy",
+      "CodeType": "Normal",
+      "NumericValue": 146,
+      "StringValue": "soy",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "soy"
+      ]
+    },
+    {
+      "CodeID": "code-94039cdb",
+      "DisplayText": "starehe",
+      "CodeType": "Normal",
+      "NumericValue": 292,
+      "StringValue": "starehe",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "starehe"
+      ]
+    },
+    {
+      "CodeID": "code-7f76391f",
+      "DisplayText": "suba",
+      "CodeType": "Normal",
+      "NumericValue": 255,
+      "StringValue": "suba",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "suba"
+      ]
+    },
+    {
+      "CodeID": "code-8def8cfb",
+      "DisplayText": "subukia",
+      "CodeType": "Normal",
+      "NumericValue": 177,
+      "StringValue": "subukia",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "subukia"
+      ]
+    },
+    {
+      "CodeID": "code-36f6fc35",
+      "DisplayText": "suna east",
+      "CodeType": "Normal",
+      "NumericValue": 258,
+      "StringValue": "suna_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "suna east"
+      ]
+    },
+    {
+      "CodeID": "code-5f2e0b98",
+      "DisplayText": "suna west",
+      "CodeType": "Normal",
+      "NumericValue": 259,
+      "StringValue": "suna_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "suna west"
+      ]
+    },
+    {
+      "CodeID": "code-d9d729bc",
+      "DisplayText": "tarbaj",
+      "CodeType": "Normal",
+      "NumericValue": 57,
+      "StringValue": "tarbaj",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tarbaj"
+      ]
+    },
+    {
+      "CodeID": "code-7e43f4e2",
+      "DisplayText": "taveta",
+      "CodeType": "Normal",
+      "NumericValue": 43,
+      "StringValue": "taveta",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "taveta"
+      ]
+    },
+    {
+      "CodeID": "code-7915cf6a",
+      "DisplayText": "teso north",
+      "CodeType": "Normal",
+      "NumericValue": 219,
+      "StringValue": "teso_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "teso north"
+      ]
+    },
+    {
+      "CodeID": "code-bae6b3f8",
+      "DisplayText": "teso south",
+      "CodeType": "Normal",
+      "NumericValue": 220,
+      "StringValue": "teso_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "teso south"
+      ]
+    },
+    {
+      "CodeID": "code-c7ec0beb",
+      "DisplayText": "tetu",
+      "CodeType": "Normal",
+      "NumericValue": 3,
+      "StringValue": "tetu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tetu"
+      ]
+    },
+    {
+      "CodeID": "code-286e7fb9",
+      "DisplayText": "tharaka",
+      "CodeType": "Normal",
+      "NumericValue": 82,
+      "StringValue": "tharaka",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tharaka"
+      ]
+    },
+    {
+      "CodeID": "code-e75f0c3b",
+      "DisplayText": "thika town",
+      "CodeType": "Normal",
+      "NumericValue": 117,
+      "StringValue": "thika_town",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "thika town"
+      ]
+    },
+    {
+      "CodeID": "code-d7742373",
+      "DisplayText": "tiaty",
+      "CodeType": "Normal",
+      "NumericValue": 162,
+      "StringValue": "tiaty",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tiaty"
+      ]
+    },
+    {
+      "CodeID": "code-5a153a39",
+      "DisplayText": "tigania east",
+      "CodeType": "Normal",
+      "NumericValue": 75,
+      "StringValue": "tigania_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tigania east"
+      ]
+    },
+    {
+      "CodeID": "code-eee62d05",
+      "DisplayText": "tigania west",
+      "CodeType": "Normal",
+      "NumericValue": 74,
+      "StringValue": "tigania_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tigania west"
+      ]
+    },
+    {
+      "CodeID": "code-7808547a",
+      "DisplayText": "tinderet",
+      "CodeType": "Normal",
+      "NumericValue": 156,
+      "StringValue": "tinderet",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tinderet"
+      ]
+    },
+    {
+      "CodeID": "code-82ae8ba3",
+      "DisplayText": "tongaren",
+      "CodeType": "Normal",
+      "NumericValue": 234,
+      "StringValue": "tongaren",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tongaren"
+      ]
+    },
+    {
+      "CodeID": "code-0d7ba2c2",
+      "DisplayText": "turbo",
+      "CodeType": "Normal",
+      "NumericValue": 147,
+      "StringValue": "turbo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "turbo"
+      ]
+    },
+    {
+      "CodeID": "code-d5893c80",
+      "DisplayText": "turkana central",
+      "CodeType": "Normal",
+      "NumericValue": 128,
+      "StringValue": "turkana_central",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "turkana central"
+      ]
+    },
+    {
+      "CodeID": "code-1c15b760",
+      "DisplayText": "turkana east",
+      "CodeType": "Normal",
+      "NumericValue": 131,
+      "StringValue": "turkana_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "turkana east"
+      ]
+    },
+    {
+      "CodeID": "code-dd9c1202",
+      "DisplayText": "turkana north",
+      "CodeType": "Normal",
+      "NumericValue": 126,
+      "StringValue": "turkana_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "turkana north"
+      ]
+    },
+    {
+      "CodeID": "code-ac037e32",
+      "DisplayText": "turkana south",
+      "CodeType": "Normal",
+      "NumericValue": 130,
+      "StringValue": "turkana_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "turkana south"
+      ]
+    },
+    {
+      "CodeID": "code-36f88704",
+      "DisplayText": "turkana west",
+      "CodeType": "Normal",
+      "NumericValue": 127,
+      "StringValue": "turkana_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "turkana west"
+      ]
+    },
+    {
+      "CodeID": "code-f5a6abce",
+      "DisplayText": "ugenya",
+      "CodeType": "Normal",
+      "NumericValue": 235,
+      "StringValue": "ugenya",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ugenya"
+      ]
+    },
+    {
+      "CodeID": "code-caabe734",
+      "DisplayText": "ugunja",
+      "CodeType": "Normal",
+      "NumericValue": 236,
+      "StringValue": "ugunja",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ugunja"
+      ]
+    },
+    {
+      "CodeID": "code-8a077735",
+      "DisplayText": "uriri",
+      "CodeType": "Normal",
+      "NumericValue": 260,
+      "StringValue": "uriri",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "uriri"
+      ]
+    },
+    {
+      "CodeID": "code-5199d1bb",
+      "DisplayText": "vihiga",
+      "CodeType": "Normal",
+      "NumericValue": 214,
+      "StringValue": "vihiga",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "vihiga"
+      ]
+    },
+    {
+      "CodeID": "code-b2a2e8f2",
+      "DisplayText": "voi",
+      "CodeType": "Normal",
+      "NumericValue": 46,
+      "StringValue": "voi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "voi"
+      ]
+    },
+    {
+      "CodeID": "code-3ad5ca01",
+      "DisplayText": "wajir south",
+      "CodeType": "Normal",
+      "NumericValue": 55,
+      "StringValue": "wajir_south",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "wajir south"
+      ]
+    },
+    {
+      "CodeID": "code-27fdb468",
+      "DisplayText": "wajir east",
+      "CodeType": "Normal",
+      "NumericValue": 54,
+      "StringValue": "wajir_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "wajir east"
+      ]
+    },
+    {
+      "CodeID": "code-3ddc64d9",
+      "DisplayText": "wajir north",
+      "CodeType": "Normal",
+      "NumericValue": 53,
+      "StringValue": "wajir_north",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "wajir north"
+      ]
+    },
+    {
+      "CodeID": "code-e4711bf9",
+      "DisplayText": "wajir west",
+      "CodeType": "Normal",
+      "NumericValue": 56,
+      "StringValue": "wajir_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "wajir west"
+      ]
+    },
+    {
+      "CodeID": "code-6c4c352c",
+      "DisplayText": "webuye east",
+      "CodeType": "Normal",
+      "NumericValue": 231,
+      "StringValue": "webuye_east",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "webuye east"
+      ]
+    },
+    {
+      "CodeID": "code-75f36166",
+      "DisplayText": "webuye west",
+      "CodeType": "Normal",
+      "NumericValue": 232,
+      "StringValue": "webuye_west",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "webuye west"
+      ]
+    },
+    {
+      "CodeID": "code-8b543ced",
+      "DisplayText": "west mugirango",
+      "CodeType": "Normal",
+      "NumericValue": 274,
+      "StringValue": "west_mugirango",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "west mugirango"
+      ]
+    },
+    {
+      "CodeID": "code-e18896f5",
+      "DisplayText": "westlands",
+      "CodeType": "Normal",
+      "NumericValue": 277,
+      "StringValue": "westlands",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "westlands"
+      ]
+    },
+    {
+      "CodeID": "code-b72dbb72",
+      "DisplayText": "wundanyi",
+      "CodeType": "Normal",
+      "NumericValue": 44,
+      "StringValue": "wundanyi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "wundanyi"
+      ]
+    },
+    {
+      "CodeID": "code-f6ad7f2c",
+      "DisplayText": "yatta",
+      "CodeType": "Normal",
+      "NumericValue": 96,
+      "StringValue": "yatta",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "yatta"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "StringValue": "impact",
+      "NumericValue": -100140,
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/code_schemes/kenya_constituency.json
+++ b/code_schemes/kenya_constituency.json
@@ -4,6 +4,16 @@
   "Version": "0.0.0.3",
   "Codes": [
     {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
       "CodeID": "code-b8bbb7e8",
       "DisplayText": "ainabkoi",
       "CodeType": "Normal",
@@ -3237,6 +3247,15 @@
       "NumericValue": -50,
       "StringValue": "NIC",
       "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
     },
     {
       "CodeID": "code-STOP-08b832a8",

--- a/code_schemes/kenya_county.json
+++ b/code_schemes/kenya_county.json
@@ -1,0 +1,704 @@
+{
+  "SchemeID": "Scheme-af6c3ef0",
+  "Name": "Kenya County",
+  "Version": "0.0.0.2",
+  "Codes": [
+    {
+      "CodeID": "code-d87fee17",
+      "DisplayText": "baringo",
+      "CodeType": "Normal",
+      "NumericValue": 3,
+      "StringValue": "baringo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "baringo"
+      ]
+    },
+    {
+      "CodeID": "code-07cab7b4",
+      "DisplayText": "bomet",
+      "CodeType": "Normal",
+      "NumericValue": 4,
+      "StringValue": "bomet",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bomet"
+      ]
+    },
+    {
+      "CodeID": "code-d44c52b4",
+      "DisplayText": "bungoma",
+      "CodeType": "Normal",
+      "NumericValue": 5,
+      "StringValue": "bungoma",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bungoma"
+      ]
+    },
+    {
+      "CodeID": "code-fe358835",
+      "DisplayText": "busia",
+      "CodeType": "Normal",
+      "NumericValue": 6,
+      "StringValue": "busia",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "busia"
+      ]
+    },
+    {
+      "CodeID": "code-4e2333e0",
+      "DisplayText": "elgeyo marakwet",
+      "CodeType": "Normal",
+      "NumericValue": 7,
+      "StringValue": "elgeyo_marakwet",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "elgeyo marakwet"
+      ]
+    },
+    {
+      "CodeID": "code-f5f1f8b7",
+      "DisplayText": "embu",
+      "CodeType": "Normal",
+      "NumericValue": 8,
+      "StringValue": "embu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "embu"
+      ]
+    },
+    {
+      "CodeID": "code-915318fe",
+      "DisplayText": "garissa",
+      "CodeType": "Normal",
+      "NumericValue": 9,
+      "StringValue": "garissa",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "garissa"
+      ]
+    },
+    {
+      "CodeID": "code-6ea8fed9",
+      "DisplayText": "homa bay",
+      "CodeType": "Normal",
+      "NumericValue": 10,
+      "StringValue": "homa_bay",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "homa bay"
+      ]
+    },
+    {
+      "CodeID": "code-ea64f7b4",
+      "DisplayText": "isiolo",
+      "CodeType": "Normal",
+      "NumericValue": 11,
+      "StringValue": "isiolo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "isiolo"
+      ]
+    },
+    {
+      "CodeID": "code-ccc0d7bc",
+      "DisplayText": "kajiado",
+      "CodeType": "Normal",
+      "NumericValue": 12,
+      "StringValue": "kajiado",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kajiado"
+      ]
+    },
+    {
+      "CodeID": "code-7e60db65",
+      "DisplayText": "kakamega",
+      "CodeType": "Normal",
+      "NumericValue": 13,
+      "StringValue": "kakamega",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kakamega"
+      ]
+    },
+    {
+      "CodeID": "code-1ac0821e",
+      "DisplayText": "kericho",
+      "CodeType": "Normal",
+      "NumericValue": 14,
+      "StringValue": "kericho",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kericho"
+      ]
+    },
+    {
+      "CodeID": "code-ce38a3c0",
+      "DisplayText": "kiambu",
+      "CodeType": "Normal",
+      "NumericValue": 15,
+      "StringValue": "kiambu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kiambu"
+      ]
+    },
+    {
+      "CodeID": "code-80c34fcb",
+      "DisplayText": "kilifi",
+      "CodeType": "Normal",
+      "NumericValue": 16,
+      "StringValue": "kilifi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kilifi"
+      ]
+    },
+    {
+      "CodeID": "code-6ff5616f",
+      "DisplayText": "kirinyaga",
+      "CodeType": "Normal",
+      "NumericValue": 1,
+      "StringValue": "kirinyaga",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kirinyaga"
+      ]
+    },
+    {
+      "CodeID": "code-ff587bc2",
+      "DisplayText": "kisii",
+      "CodeType": "Normal",
+      "NumericValue": 18,
+      "StringValue": "kisii",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kisii"
+      ]
+    },
+    {
+      "CodeID": "code-c33beb50",
+      "DisplayText": "kisumu",
+      "CodeType": "Normal",
+      "NumericValue": 19,
+      "StringValue": "kisumu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kisumu"
+      ]
+    },
+    {
+      "CodeID": "code-a9679a64",
+      "DisplayText": "kitui",
+      "CodeType": "Normal",
+      "NumericValue": 20,
+      "StringValue": "kitui",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kitui"
+      ]
+    },
+    {
+      "CodeID": "code-eb1b795f",
+      "DisplayText": "kwale",
+      "CodeType": "Normal",
+      "NumericValue": 21,
+      "StringValue": "kwale",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kwale"
+      ]
+    },
+    {
+      "CodeID": "code-6d8ebc01",
+      "DisplayText": "laikipia",
+      "CodeType": "Normal",
+      "NumericValue": 22,
+      "StringValue": "laikipia",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "laikipia"
+      ]
+    },
+    {
+      "CodeID": "code-8e700c06",
+      "DisplayText": "lamu",
+      "CodeType": "Normal",
+      "NumericValue": 46,
+      "StringValue": "lamu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lamu"
+      ]
+    },
+    {
+      "CodeID": "code-200d8b4b",
+      "DisplayText": "machakos",
+      "CodeType": "Normal",
+      "NumericValue": 23,
+      "StringValue": "machakos",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "machakos"
+      ]
+    },
+    {
+      "CodeID": "code-99f1aae2",
+      "DisplayText": "makueni",
+      "CodeType": "Normal",
+      "NumericValue": 24,
+      "StringValue": "makueni",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "makueni"
+      ]
+    },
+    {
+      "CodeID": "code-d1f6da00",
+      "DisplayText": "mandera",
+      "CodeType": "Normal",
+      "NumericValue": 25,
+      "StringValue": "mandera",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mandera"
+      ]
+    },
+    {
+      "CodeID": "code-f247f6b5",
+      "DisplayText": "marsabit",
+      "CodeType": "Normal",
+      "NumericValue": 26,
+      "StringValue": "marsabit",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "marsabit"
+      ]
+    },
+    {
+      "CodeID": "code-1ac0ded3",
+      "DisplayText": "meru",
+      "CodeType": "Normal",
+      "NumericValue": 27,
+      "StringValue": "meru",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "meru"
+      ]
+    },
+    {
+      "CodeID": "code-fcdd860c",
+      "DisplayText": "migori",
+      "CodeType": "Normal",
+      "NumericValue": 28,
+      "StringValue": "migori",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "migori"
+      ]
+    },
+    {
+      "CodeID": "code-9c866083",
+      "DisplayText": "mombasa",
+      "CodeType": "Normal",
+      "NumericValue": 29,
+      "StringValue": "mombasa",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mombasa"
+      ]
+    },
+    {
+      "CodeID": "code-607bec6c",
+      "DisplayText": "murang'a",
+      "CodeType": "Normal",
+      "NumericValue": 2,
+      "StringValue": "muranga",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "muranga"
+      ]
+    },
+    {
+      "CodeID": "code-9f581e05",
+      "DisplayText": "nairobi",
+      "CodeType": "Normal",
+      "NumericValue": 30,
+      "StringValue": "nairobi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nairobi"
+      ]
+    },
+    {
+      "CodeID": "code-ccf96206",
+      "DisplayText": "nakuru",
+      "CodeType": "Normal",
+      "NumericValue": 17,
+      "StringValue": "nakuru",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nakuru"
+      ]
+    },
+    {
+      "CodeID": "code-ded4dcc9",
+      "DisplayText": "nandi",
+      "CodeType": "Normal",
+      "NumericValue": 31,
+      "StringValue": "nandi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nandi"
+      ]
+    },
+    {
+      "CodeID": "code-2640aeb0",
+      "DisplayText": "narok",
+      "CodeType": "Normal",
+      "NumericValue": 32,
+      "StringValue": "narok",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "narok"
+      ]
+    },
+    {
+      "CodeID": "code-ee9b024d",
+      "DisplayText": "nyamira",
+      "CodeType": "Normal",
+      "NumericValue": 33,
+      "StringValue": "nyamira",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyamira"
+      ]
+    },
+    {
+      "CodeID": "code-03aff04f",
+      "DisplayText": "nyandarua",
+      "CodeType": "Normal",
+      "NumericValue": 34,
+      "StringValue": "nyandarua",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyandarua"
+      ]
+    },
+    {
+      "CodeID": "code-9f7f9712",
+      "DisplayText": "nyeri",
+      "CodeType": "Normal",
+      "NumericValue": 0,
+      "StringValue": "nyeri",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nyeri"
+      ]
+    },
+    {
+      "CodeID": "code-f3e716e5",
+      "DisplayText": "samburu",
+      "CodeType": "Normal",
+      "NumericValue": 35,
+      "StringValue": "samburu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "samburu"
+      ]
+    },
+    {
+      "CodeID": "code-11ea6ab8",
+      "DisplayText": "siaya",
+      "CodeType": "Normal",
+      "NumericValue": 44,
+      "StringValue": "siaya",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "siaya"
+      ]
+    },
+    {
+      "CodeID": "code-a05e615d",
+      "DisplayText": "taita taveta",
+      "CodeType": "Normal",
+      "NumericValue": 36,
+      "StringValue": "taita_taveta",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "taita taveta"
+      ]
+    },
+    {
+      "CodeID": "code-0ca3f68c",
+      "DisplayText": "tana river",
+      "CodeType": "Normal",
+      "NumericValue": 45,
+      "StringValue": "tana_river",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tana river"
+      ]
+    },
+    {
+      "CodeID": "code-0caef052",
+      "DisplayText": "tharaka nithi",
+      "CodeType": "Normal",
+      "NumericValue": 37,
+      "StringValue": "tharaka_nithi",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tharaka nithi"
+      ]
+    },
+    {
+      "CodeID": "code-be7e288b",
+      "DisplayText": "trans nzoia",
+      "CodeType": "Normal",
+      "NumericValue": 38,
+      "StringValue": "trans_nzoia",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "trans nzoia"
+      ]
+    },
+    {
+      "CodeID": "code-e39dec1e",
+      "DisplayText": "turkana",
+      "CodeType": "Normal",
+      "NumericValue": 39,
+      "StringValue": "turkana",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "turkana"
+      ]
+    },
+    {
+      "CodeID": "code-a342709b",
+      "DisplayText": "uasin gishu",
+      "CodeType": "Normal",
+      "NumericValue": 40,
+      "StringValue": "uasin_gishu",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "uasin gishu"
+      ]
+    },
+    {
+      "CodeID": "code-afcb698a",
+      "DisplayText": "vihiga",
+      "CodeType": "Normal",
+      "NumericValue": 41,
+      "StringValue": "vihiga",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "vihiga"
+      ]
+    },
+    {
+      "CodeID": "code-38dd1b46",
+      "DisplayText": "wajir",
+      "CodeType": "Normal",
+      "NumericValue": 42,
+      "StringValue": "wajir",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "wajir"
+      ]
+    },
+    {
+      "CodeID": "code-5b6f773b",
+      "DisplayText": "west pokot",
+      "CodeType": "Normal",
+      "NumericValue": 43,
+      "StringValue": "west_pokot",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "west pokot"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "StringValue": "impact",
+      "NumericValue": -100140,
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/code_schemes/kenya_county.json
+++ b/code_schemes/kenya_county.json
@@ -4,6 +4,16 @@
   "Version": "0.0.0.2",
   "Codes": [
     {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
       "CodeID": "code-d87fee17",
       "DisplayText": "baringo",
       "CodeType": "Normal",
@@ -564,6 +574,15 @@
       "NumericValue": -50,
       "StringValue": "NIC",
       "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
     },
     {
       "CodeID": "code-STOP-08b832a8",

--- a/code_schemes/ws_correct_dataset.json
+++ b/code_schemes/ws_correct_dataset.json
@@ -3,7 +3,490 @@
   "Name": "WS - Correct Dataset",
   "Version": "0.0.0.1",
   "Codes": [
-
+{
+      "CodeID": "code-02d4450d",
+      "CodeType": "Normal",
+      "DisplayText": "location",
+      "StringValue": "location",
+      "NumericValue": 1,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "location"
+      ]
+    },
+    {
+      "CodeID": "code-c473f7bb",
+      "CodeType": "Normal",
+      "DisplayText": "age",
+      "StringValue": "age",
+      "NumericValue": 2,
+      "VisibleInCoda": true,
+      "MatchValues":  [
+        "age"
+      ]
+    },
+    {
+      "CodeID": "code-80edd5c3",
+      "CodeType": "Normal",
+      "DisplayText": "gender",
+      "StringValue": "gender",
+      "NumericValue": 3,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gender"
+      ]
+    },
+    {
+      "CodeID": "code-2b7a12a0",
+      "CodeType": "Normal",
+      "DisplayText": "disabled",
+      "StringValue": "disabled",
+      "NumericValue": 7,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "disabled"
+      ]
+    },
+    {
+      "CodeID": "code-aec91680",
+      "CodeType": "Normal",
+      "DisplayText": "OXFAM-WASH s01e01",
+      "StringValue": "oxfam_wash_s01e01",
+      "NumericValue": 4,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "OXFAM-WASH s01e01"
+      ]
+    },
+    {
+      "CodeID": "code-d6d8acd5",
+      "CodeType": "Normal",
+      "DisplayText": "OXFAM-WASH s01e02",
+      "StringValue": "oxfam_wash_s01e02",
+      "NumericValue": 5,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "OXFAM-WASH s01e02"
+      ]
+    },
+    {
+      "CodeID": "code-7934d45b",
+      "CodeType": "Normal",
+      "DisplayText": "OXFAM-WASH s01e03",
+      "StringValue": "oxfam_wash_s01e03",
+      "NumericValue": 6,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "OXFAM-WASH s01e03"
+      ]
+    },
+    {
+      "CodeID": "code-5ca601dc",
+      "CodeType": "Normal",
+      "DisplayText": "OXFAM WASH Beneficiary Consent",
+      "StringValue": "oxfam_wash_beneficiary_consent",
+      "NumericValue": 8,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "OXFAM WASH Beneficiary Consent"
+      ]
+    },
+    {
+      "CodeID": "code-314f1554",
+      "CodeType": "Normal",
+      "DisplayText": "OXFAM WASH s01e03 noise handler",
+      "StringValue": "oxfam_wash_s01e03_noise_handler",
+      "NumericValue": 9,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "OXFAM WASH s01e03 Noise Handler"
+      ]
+    },
+    {
+      "CodeID": "code-9d692d92",
+      "CodeType": "Normal",
+      "DisplayText": "OXFAM WASH s01 programme evaluation",
+      "StringValue": "oxfam_wash_s01_programme_evaluation",
+      "NumericValue": 10,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "OXFAM WASH s01 Programme Evaluation"
+      ]
+    },
+    {
+      "CodeID": "code-5c365ea9",
+      "CodeType": "Normal",
+      "DisplayText": "OXFAM WASH s01 Accountability",
+      "StringValue": "oxfam_wash_s01_accountability",
+      "NumericValue": 11,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "OXFAM WASH s01 Accountability"
+      ]
+    },
+    {
+      "CodeID": "code-382603bc",
+      "CodeType": "Normal",
+      "DisplayText": "OXFAM WASH S01 Close Out",
+      "StringValue": "oxfam_wash_s01_close_out",
+      "NumericValue": 12,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "OXFAM WASH S01 Close Out"
+      ]
+    },
+    {
+      "CodeID": "code-eb71f375",
+      "CodeType": "Normal",
+      "DisplayText": "WorldVision s01e01",
+      "StringValue": "worldvision_s01e01",
+      "NumericValue": 104,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "WorldVision s01e01"
+      ]
+    },
+    {
+      "CodeID": "code-21b6b981",
+      "CodeType": "Normal",
+      "DisplayText": "WorldVision s01e02",
+      "StringValue": "worldvision_s01e02",
+      "NumericValue": 105,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "WorldVision s01e02"
+      ]
+    },
+    {
+      "CodeID": "code-a0ec4383",
+      "CodeType": "Normal",
+      "DisplayText": "WorldVision s01e03",
+      "StringValue": "worldvision_s01e03",
+      "NumericValue": 106,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "WorldVision s01e03"
+      ]
+    },
+    {
+      "CodeID": "code-42b1a456",
+      "CodeType": "Normal",
+      "DisplayText": "WorldVision s01 close-out",
+      "StringValue": "world_vision_s01_close_out",
+      "NumericValue": 107,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "WorldVision s01 close-out"
+      ]
+    },
+    {
+      "CodeID": "code-f1791199",
+      "CodeType": "Normal",
+      "DisplayText": "UNDP-Kenya s01e01",
+      "StringValue": "undp_kenya_s01e01",
+      "NumericValue": 201,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNDP-Kenya s01e01"
+      ]
+    },
+    {
+      "CodeID": "code-652b4fe8",
+      "CodeType": "Normal",
+      "DisplayText": "UNDP-Kenya s01e02",
+      "StringValue": "undp_kenya_s01e02",
+      "NumericValue": 202,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNDP-Kenya s01e02"
+      ]
+    },
+    {
+      "CodeID": "code-64decee7",
+      "CodeType": "Normal",
+      "DisplayText": "UNDP-Kenya s01e03",
+      "StringValue": "undp_kenya_s01e03",
+      "NumericValue": 203,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNDP-Kenya s01e03"
+      ]
+    },
+    {
+      "CodeID": "code-9ee88d2e",
+      "CodeType": "Normal",
+      "DisplayText": "UNDP-Kenya s01e04",
+      "StringValue": "undp_kenya_s01e04",
+      "NumericValue": 204,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNDP-Kenya s01e04"
+      ]
+    },
+    {
+      "CodeID": "code-f5ac097b",
+      "CodeType": "Normal",
+      "DisplayText": "UNDP-Kenya s01e05",
+      "StringValue": "undp_kenya_s01e05",
+      "NumericValue": 205,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNDP-Kenya s01e05"
+      ]
+    },
+    {
+      "CodeID": "code-3ffde4f3",
+      "CodeType": "Normal",
+      "DisplayText": "UNDP-Kenya s01e06",
+      "StringValue": "undp_kenya_s01e06",
+      "NumericValue": 206,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNDP-Kenya s01e06"
+      ]
+    },
+    {
+      "CodeID": "code-a7874fc3",
+      "CodeType": "Normal",
+      "DisplayText": "UNDP-Kenya s01e07",
+      "StringValue": "undp_kenya_s01e07",
+      "NumericValue": 207,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNDP-Kenya s01e07"
+      ]
+    },
+    {
+      "CodeID": "code-57077ba9",
+      "CodeType": "Normal",
+      "DisplayText": "UNDP-Kenya s01e08",
+      "StringValue": "undp_kenya_s01e08",
+      "NumericValue": 208,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNDP-Kenya s01e08"
+      ]
+    },
+    {
+      "CodeID": "code-e442c27b",
+      "CodeType": "Normal",
+      "DisplayText": "UNDP-Kenya s01 close out",
+      "StringValue": "undp_kenya_s01_close_out",
+      "NumericValue": 209,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNDP-Kenya s01 close out"
+      ]
+    },
+    {
+      "CodeID": "code-9bd0f2b1",
+      "CodeType": "Normal",
+      "DisplayText": "COVID19 s01e01",
+      "StringValue": "covid19_s01e01",
+      "NumericValue": 210,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "COVID19 s01e01"
+      ]
+    },
+    {
+      "CodeID": "code-61f91d7c",
+      "CodeType": "Normal",
+      "DisplayText": "COVID19 s01e02",
+      "StringValue": "covid19_s01e02",
+      "NumericValue": 211,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "COVID19 s01e02"
+      ]
+    },
+    {
+      "CodeID": "code-4dc81f3b",
+      "CodeType": "Normal",
+      "DisplayText": "COVID19-KE-Urban s01e01",
+      "StringValue": "covid19_ke_urban_s01e01",
+      "NumericValue": 212,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "COVID19-KE-Urban s01e01"
+      ]
+    },
+    {
+      "CodeID": "code-44371d98",
+      "CodeType": "Normal",
+      "DisplayText": "COVID19-KE-Urban s01e02",
+      "StringValue": "covid19_ke_urban_s01e02",
+      "NumericValue": 213,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "COVID19-KE-Urban s01e02"
+      ]
+    },
+    {
+      "CodeID": "code-9113887d",
+      "CodeType": "Normal",
+      "DisplayText": "COVID19-KE-Urban s01e03",
+      "StringValue": "covid19_ke_urban_s01e03",
+      "NumericValue": 214,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "COVID19-KE-Urban s01e03"
+      ]
+    },
+    {
+      "CodeID": "code-eaaec5b8",
+      "CodeType": "Normal",
+      "DisplayText": "COVID19-KE-Urban s01e04",
+      "StringValue": "covid19_ke_urban_s01e04",
+      "NumericValue": 215,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "COVID19-KE-Urban s01e04"
+      ]
+    },
+    {
+      "CodeID": "code-bf7e7e9f",
+      "CodeType": "Normal",
+      "DisplayText": "COVID19-KE-Urban s01e05",
+      "StringValue": "covid19_ke_urban_s01e05",
+      "NumericValue": 216,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "COVID19-KE-Urban s01e05"
+      ]
+    },
+    {
+      "CodeID": "code-1770ab02",
+      "CodeType": "Normal",
+      "DisplayText": "COVID19-KE-Urban s01e06",
+      "StringValue": "covid19_ke_urban_s01e06",
+      "NumericValue": 217,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "COVID19-KE-Urban s01e06"
+      ]
+    },
+    {
+      "CodeID": "code-be80a219",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e01",
+      "StringValue": "unicef_covid19_ke_s01e01",
+      "NumericValue": 301,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e01"
+      ]
+    },
+    {
+      "CodeID": "code-501501c6",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e02",
+      "StringValue": "unicef_covid19_ke_s01e02",
+      "NumericValue": 302,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e02"
+      ]
+    },
+    {
+      "CodeID": "code-33462fdd",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e03",
+      "StringValue": "unicef_covid19_ke_s01e03",
+      "NumericValue": 303,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e03"
+      ]
+    },
+    {
+      "CodeID": "code-f244ec46",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e04",
+      "StringValue": "unicef_covid19_ke_s01e04",
+      "NumericValue": 304,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e04"
+      ]
+    },
+    {
+      "CodeID": "code-7ca47153",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e05",
+      "StringValue": "unicef_covid19_ke_s01e05",
+      "NumericValue": 305,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e05"
+      ]
+    },
+    {
+      "CodeID": "code-f947ea68",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e06",
+      "StringValue": "unicef_covid19_ke_s01e06",
+      "NumericValue": 306,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e06"
+      ]
+    },
+    {
+      "CodeID": "code-1b1ee235",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e07",
+      "StringValue": "unicef_covid19_ke_s01e07",
+      "NumericValue": 307,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e07"
+      ]
+    },
+    {
+      "CodeID": "code-2ad25486",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e08",
+      "StringValue": "unicef_covid19_ke_s01e08",
+      "NumericValue": 308,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e08"
+      ]
+    },
+    {
+      "CodeID": "code-b62ffd3c",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e09",
+      "StringValue": "unicef_covid19_ke_s01e09",
+      "NumericValue": 309,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e09"
+      ]
+    },
+    {
+      "CodeID": "code-51167ad3",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01e10",
+      "StringValue": "unicef_covid19_ke_s01e10",
+      "NumericValue": 310,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01e10"
+      ]
+    },
+    {
+      "CodeID": "code-dbd4fbf3",
+      "CodeType": "Normal",
+      "DisplayText": "UNICEF-COVID19-KE s01 close out",
+      "StringValue": "unicef_covid19_ke_s01_close_out",
+      "NumericValue": 311,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "UNICEF-COVID19-KE s01 close out"
+      ]
+    },
     {
       "CodeID": "code-NC-42f1d983",
       "CodeType": "Control",

--- a/code_schemes/ws_correct_dataset.json
+++ b/code_schemes/ws_correct_dataset.json
@@ -1,8 +1,9 @@
 {
-  "SchemeID": "Scheme-fffffa79-change-me",
+  "SchemeID": "Scheme-fffffbfc",
   "Name": "WS - Correct Dataset",
   "Version": "0.0.0.1",
   "Codes": [
+
     {
       "CodeID": "code-NC-42f1d983",
       "CodeType": "Control",

--- a/combine_coda_datasets.py
+++ b/combine_coda_datasets.py
@@ -1,0 +1,118 @@
+import argparse
+import glob
+import json
+
+from core_data_modules.data_models import Message
+
+
+def latest_labels(labels):
+    out = []
+    seen_scheme_ids = set()
+    for l in labels:
+        if l.code_id == "SPECIAL-MANUALLY_UNCODED":
+            continue
+        if l.scheme_id not in seen_scheme_ids:
+            out.append(l)
+            seen_scheme_ids.add(l.scheme_id)
+    return out
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Combines the various Coda demographic datasets from the previous "
+                                                 "pool projects and combines them into one dataset.")
+
+    parser.add_argument("input_dir", metavar="input-dir",
+                        help="A directory containing the Coda messages files to combine. Each file should be in the "
+                             "format {ProjectName}_{demog}. This script supports datasets from COVID19, WorldVision, "
+                             "OXFAM-WASH, and UNICEF-COVID19_KE as of March 2021")
+    parser.add_argument("output_dir", metavar="output-dir",
+                        help="A directory to write the combined messages files to. Files will be written in the "
+                             "format Kenya_Pool_{demog}")
+
+    args = parser.parse_args()
+    input_dir = args.input_dir
+    output_dir = args.output_dir
+
+    for demog in ["gender", "age", "location", "disabled"]:
+        print()
+        print(demog)
+        input_datasets = glob.glob(f"{input_dir}/*_{demog}.json")
+        output_messages = dict()  # of message id -> message
+        conflicting_messages = set()  # of message id. This will contain messages that appear in multiple datasets and have different codes
+        for path in input_datasets:
+            with open(path) as f:
+                messages = [Message.from_firebase_map(m) for m in json.load(f)]
+                print(f"Loaded {len(messages)} messages from {path}")
+                for m in messages:
+                    if m.message_id not in output_messages:
+                        output_messages[m.message_id] = m
+                    else:
+                        message_label_ids = {x.code_id for x in latest_labels(m.labels)}
+                        existing_message_label_ids = {x.code_id for x in latest_labels(output_messages[m.message_id].labels)}
+                        if message_label_ids != existing_message_label_ids:
+                            print("Differing labels", message_label_ids, existing_message_label_ids, m.text)
+                            conflicting_messages.add(m.message_id)
+
+                    for l in m.labels:
+                        # Rewrite scheme and code ids that represent the same concept but were different across
+                        # the input projects.
+
+                        # Gender
+                        if l.scheme_id == "Scheme-2bba4420":
+                            l.scheme_id = "Scheme-12cb6f95"
+
+                        # Age
+                        if l.scheme_id == "Scheme-016f646a":
+                            l.scheme_id = "Scheme-4189e74c"
+
+                        # Constituency
+                        if l.scheme_id == "Scheme-a992ef8f":
+                            l.scheme_id = "Scheme-4c5b955d"
+
+                        # County
+                        if l.scheme_id == "Scheme-81b34b9d":
+                            l.scheme_id = "Scheme-af6c3ef0"
+
+                        # WorldVision WS remaps
+                        if l.scheme_id == "Scheme-ffff1797":
+                            if l.code_id == "code-9bd0f2b1":  # s01e01
+                                l.code_id = "code-eb71f375"
+                            if l.code_id == "code-f0c22231":  # s01e02
+                                l.code_id = "code-21b6b981"
+                            if l.code_id == "code-c6d30e11":  # s01e03
+                                l.code_id = "code-a0ec4383"
+
+                        # Oxfam WS remaps
+                        if l.scheme_id == "Scheme-ffff43a6":
+                            if l.code_id == "code-be80a219":  # s01e01
+                                l.code_id = "code-aec91680"
+                            if l.code_id == "code-501501c6":  # s01e02
+                                l.code_id = "code-d6d8acd5"
+                            if l.code_id == "code-33462fdd":  # s01e03
+                                l.code_id = "code-7934d45b"
+
+                        # WS - Correct Dataset
+                        if l.scheme_id.startswith("Scheme-ffff"):
+                            l.scheme_id = "Scheme-fffffbfc"
+
+                        # WS age
+                        if l.code_id in {"code-70ac05ab"}:
+                            l.code_id = "code-c473f7bb"
+                        # WS location
+                        if l.code_id in {"code-dda6e4b4"}:
+                            l.code_id = "code-02d4450d"
+                        # WS gender
+                        if l.code_id in {"code-6774cedd"}:
+                            l.code_id = "code-80edd5c3"
+
+        with open(f"{output_dir}/Kenya_Pool_{demog}.json", "w") as f:
+            messages_to_write = output_messages.values()
+            for m in messages_to_write:
+                # If the labels that were assigned conflict between different datasets, require these to be labelled
+                # again. To speed up the process, keep one of the sets of labels that was applied but just set
+                # checked to False.
+                if m.message_id in conflicting_messages:
+                    for l in latest_labels(m.labels):
+                        l.checked = False
+
+            json.dump([m.to_firebase_map() for m in messages_to_write], f)

--- a/combine_coda_datasets.py
+++ b/combine_coda_datasets.py
@@ -35,7 +35,6 @@ if __name__ == "__main__":
 
     for demog in ["gender", "age", "location", "disabled"]:
         print()
-        print(demog)
         input_datasets = glob.glob(f"{input_dir}/*_{demog}.json")
         output_messages = dict()  # of message id -> message
         conflicting_messages = set()  # of message id. This will contain messages that appear in multiple datasets and have different codes

--- a/combine_coda_datasets.py
+++ b/combine_coda_datasets.py
@@ -34,7 +34,6 @@ if __name__ == "__main__":
     output_dir = args.output_dir
 
     for demog in ["gender", "age", "location", "disabled"]:
-        print()
         input_datasets = glob.glob(f"{input_dir}/*_{demog}.json")
         output_messages = dict()  # of message id -> message
         conflicting_messages = set()  # of message id. This will contain messages that appear in multiple datasets and have different codes

--- a/configurations/code_imputation_functions.py
+++ b/configurations/code_imputation_functions.py
@@ -1,0 +1,118 @@
+import time
+
+from core_data_modules.cleaners import Codes
+from core_data_modules.cleaners.cleaning_utils import CleaningUtils
+from core_data_modules.cleaners.location_tools import SomaliaLocations, KenyaLocations
+from core_data_modules.data_models.code_scheme import CodeTypes
+from core_data_modules.traced_data import Metadata
+
+from configurations.code_schemes import CodeSchemes
+
+
+def make_location_code(scheme, clean_value):
+    if clean_value == Codes.NOT_CODED:
+        return scheme.get_code_with_control_code(Codes.NOT_CODED)
+    else:
+        return scheme.get_code_with_match_value(clean_value)
+
+
+def impute_kenya_location_codes(user, data, location_configurations):
+    for td in data:
+        # Up to 1 location code should have been assigned in Coda. Search for that code,
+        # ensuring that only 1 has been assigned or, if multiple have been assigned, that they are non-conflicting
+        # control codes
+        location_code = None
+
+        for cc in location_configurations:
+            coda_code = cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"])
+            if location_code is not None:
+                if not (
+                        coda_code.code_id == location_code.code_id or coda_code.control_code == Codes.NOT_REVIEWED):
+                    location_code = CodeSchemes.KENYA_CONSTITUENCY.get_code_with_control_code(Codes.CODING_ERROR)
+            elif coda_code.control_code != Codes.NOT_REVIEWED:
+                location_code = coda_code
+
+        # If no code was found, then this location is still not reviewed.
+        # Synthesise a NOT_REVIEWED code accordingly.
+        if location_code is None:
+            location_code = CodeSchemes.KENYA_CONSTITUENCY.get_code_with_control_code(Codes.NOT_REVIEWED)
+
+        # If a control or meta code was found, set all other location keys to that control/meta code,
+        # otherwise convert the provided location to the other locations in the hierarchy.
+        if location_code.code_type == CodeTypes.CONTROL:
+            for cc in location_configurations:
+                td.append_data({
+                    cc.coded_field: CleaningUtils.make_label_from_cleaner_code(
+                        cc.code_scheme,
+                        cc.code_scheme.get_code_with_control_code(location_code.control_code),
+                        Metadata.get_call_location()
+                    ).to_dict()
+                }, Metadata(user, Metadata.get_call_location(), time.time()))
+        elif location_code.code_type == CodeTypes.META:
+            for cc in location_configurations:
+                td.append_data({
+                    cc.coded_field: CleaningUtils.make_label_from_cleaner_code(
+                        cc.code_scheme,
+                        cc.code_scheme.get_code_with_meta_code(location_code.meta_code),
+                        Metadata.get_call_location()
+                    ).to_dict()
+                }, Metadata(user, Metadata.get_call_location(), time.time()))
+        else:
+            location = location_code.match_values[0]
+            td.append_data({
+                "constituency_coded": CleaningUtils.make_label_from_cleaner_code(
+                    CodeSchemes.KENYA_CONSTITUENCY,
+                    make_location_code(CodeSchemes.KENYA_CONSTITUENCY,
+                                       KenyaLocations.constituency_for_location_code(location)),
+                    Metadata.get_call_location()).to_dict(),
+                "county_coded": CleaningUtils.make_label_from_cleaner_code(
+                    CodeSchemes.KENYA_COUNTY,
+                    make_location_code(CodeSchemes.KENYA_COUNTY,
+                                       KenyaLocations.county_for_location_code(location)),
+                    Metadata.get_call_location()).to_dict()
+            }, Metadata(user, Metadata.get_call_location(), time.time()))
+
+
+def impute_age_category(user, data, age_configurations):
+    # TODO: By accepting a list of age_configurations but then requiring that list to contain code schemes in a
+    #       certain order, it looks like we're providing more flexibility than we actually do. We should change this
+    #       to explicitly accept age and age_category configurations, which requires refactoring all of the
+    #       code imputation functions.
+    age_cc = age_configurations[0]
+    age_category_cc = age_configurations[1]
+
+    age_categories = {
+        (10, 14): "10 to 14",
+        (15, 17): "15 to 17",
+        (18, 35): "18 to 35",
+        (36, 54): "36 to 54",
+        (55, 99): "55 to 99"
+    }
+
+    for td in data:
+        age_label = td[age_cc.coded_field]
+        age_code = age_cc.code_scheme.get_code_with_code_id(age_label["CodeID"])
+
+        if age_code.code_type == CodeTypes.NORMAL:
+            # TODO: If these age categories are standard across projects, move this to Core as a new cleaner.
+            age_category = None
+            for age_range, category in age_categories.items():
+                if age_range[0] <= age_code.numeric_value <= age_range[1]:
+                    age_category = category
+            assert age_category is not None
+
+            age_category_code = age_category_cc.code_scheme.get_code_with_match_value(age_category)
+        elif age_code.code_type == CodeTypes.META:
+            age_category_code = age_category_cc.code_scheme.get_code_with_meta_code(age_code.meta_code)
+        else:
+            assert age_code.code_type == CodeTypes.CONTROL
+            age_category_code = age_category_cc.code_scheme.get_code_with_control_code(age_code.control_code)
+
+        age_category_label = CleaningUtils.make_label_from_cleaner_code(
+            age_category_cc.code_scheme, age_category_code, Metadata.get_call_location()
+        )
+
+        td.append_data(
+            {age_category_cc.coded_field: age_category_label.to_dict()},
+            Metadata(user, Metadata.get_call_location(), time.time())
+        )

--- a/configurations/code_schemes.py
+++ b/configurations/code_schemes.py
@@ -13,4 +13,11 @@ class CodeSchemes(object):
     VACCINATION_THOUGHTS = _open_scheme("vaccination_thoughts.json")
     OTHER_MESSAGES = _open_scheme("other_messages.json")
 
+    GENDER = _open_scheme("gender.json")
+    AGE = _open_scheme("age.json")
+    AGE_CATEGORY = _open_scheme("age_category.json")
+    KENYA_CONSTITUENCY = _open_scheme("kenya_constituency.json")
+    KENYA_COUNTY = _open_scheme("kenya_county.json")
+    DISABLED = _open_scheme("disabled.json")
+
     WS_CORRECT_DATASET = _open_scheme("ws_correct_dataset.json")

--- a/configurations/coding_plans.py
+++ b/configurations/coding_plans.py
@@ -81,7 +81,7 @@ def get_demog_coding_plans(pipeline_name):
                     fold_strategy=FoldStrategies.assert_label_ids_equal
                 )
             ],
-            # ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("gender"),
+            ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("gender"),
             raw_field_fold_strategy=FoldStrategies.assert_equal
         ),
 
@@ -108,7 +108,7 @@ def get_demog_coding_plans(pipeline_name):
                        )
                    ],
                    code_imputation_function=code_imputation_functions.impute_age_category,
-                   # ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("age"),
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("age"),
                    raw_field_fold_strategy=FoldStrategies.assert_equal),
 
         CodingPlan(dataset_name="location",
@@ -132,7 +132,7 @@ def get_demog_coding_plans(pipeline_name):
                        )
                    ],
                    code_imputation_function=code_imputation_functions.impute_kenya_location_codes,
-                   # ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("location"),
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("location"),
                    raw_field_fold_strategy=FoldStrategies.assert_equal),
 
         CodingPlan(dataset_name="disabled",
@@ -148,7 +148,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal
                        )
                    ],
-                   # ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("disabled"),
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("disabled"),
                    raw_field_fold_strategy=FoldStrategies.assert_equal)
     ]
 

--- a/configurations/coding_plans.py
+++ b/configurations/coding_plans.py
@@ -1,11 +1,25 @@
 from functools import partial
 
-from core_data_modules.cleaners import swahili
+from core_data_modules.cleaners import swahili, Codes
 from core_data_modules.data_models import CodeScheme
 from core_data_modules.traced_data.util.fold_traced_data import FoldStrategies
 
+from configurations import code_imputation_functions
 from configurations.code_schemes import CodeSchemes
 from src.lib.configuration_objects import CodingConfiguration, CodingModes, CodingPlan
+
+
+def clean_age_with_range_filter(text):
+    """
+    Cleans age from the given `text`, setting to NC if the cleaned age is not in the range 10 <= age < 100.
+    """
+    age = swahili.DemographicCleaner.clean_age(text)
+    if type(age) == int and 10 <= age < 100:
+        return str(age)
+        # TODO: Once the cleaners are updated to not return Codes.NOT_CODED, this should be updated to still return
+        #       NC in the case where age is an int but is out of range
+    else:
+        return Codes.NOT_CODED
 
 
 def get_rqa_coding_plans(pipeline_name):
@@ -51,7 +65,92 @@ def get_rqa_coding_plans(pipeline_name):
 
 
 def get_demog_coding_plans(pipeline_name):
-    return []
+    return [
+        CodingPlan(
+            dataset_name="gender",
+            raw_field="gender_raw",
+            time_field="gender_time",
+            coda_filename="Kenya_Pool_gender.json",
+            coding_configurations=[
+                CodingConfiguration(
+                    coding_mode=CodingModes.SINGLE,
+                    code_scheme=CodeSchemes.GENDER,
+                    cleaner=swahili.DemographicCleaner.clean_gender,
+                    coded_field="gender_coded",
+                    analysis_file_key="gender",
+                    fold_strategy=FoldStrategies.assert_label_ids_equal
+                )
+            ],
+            # ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("gender"),
+            raw_field_fold_strategy=FoldStrategies.assert_equal
+        ),
+
+        CodingPlan(dataset_name="age",
+                   raw_field="age_raw",
+                   time_field="age_time",
+                   coda_filename="Kenya_Pool_age.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.AGE,
+                           cleaner=clean_age_with_range_filter,
+                           coded_field="age_coded",
+                           analysis_file_key="age",
+                           include_in_theme_distribution=False,
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       ),
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.AGE_CATEGORY,
+                           coded_field="age_category_coded",
+                           analysis_file_key="age_category",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   code_imputation_function=code_imputation_functions.impute_age_category,
+                   # ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("age"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(dataset_name="location",
+                   raw_field="location_raw",
+                   time_field="location_time",
+                   coda_filename="Kenya_Pool_location.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.KENYA_COUNTY,
+                           coded_field="county_coded",
+                           analysis_file_key="county",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       ),
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.KENYA_CONSTITUENCY,
+                           coded_field="constituency_coded",
+                           analysis_file_key="constituency",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   code_imputation_function=code_imputation_functions.impute_kenya_location_codes,
+                   # ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("location"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(dataset_name="disabled",
+                   raw_field="disabled_raw",
+                   time_field="disabled_time",
+                   coda_filename="Kenya_Pool_disabled.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.DISABLED,
+                           coded_field="disabled_coded",
+                           analysis_file_key="disabled",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   # ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("disabled"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal)
+    ]
 
 
 def get_ws_correct_dataset_scheme(pipeline_name):

--- a/configurations/pipeline_config.json
+++ b/configurations/pipeline_config.json
@@ -17,6 +17,85 @@
         "7aaf3325-6222-4d9e-b7ed-93b4ef78e5be",
         "93b43c8c-e261-4cff-b044-1bc5e6c3d5a1"
       ]
+    },
+    {
+      "SourceType": "RapidPro",
+      "Domain": "textit.in",
+      "TokenFileURL": "gs://avf-credentials/covid19-2-text-it-token.txt",
+      "ActivationFlowNames": [
+
+      ],
+      "SurveyFlowNames": [
+        "undp_kenya_s01_demog",
+        "covid19_ke_urban_s01_demog"
+      ],
+      "TestContactUUIDs": [
+        "eed078e5-7d13-4f3c-ac93-8b477125b31d",
+        "67836f40-a155-4757-850c-b407bd1cd475",
+        "9651e5f4-feca-4d51-a143-5c66e77ec751"
+      ]
+    },
+    {
+      "SourceType": "RapidPro",
+      "Domain": "textit.in",
+      "TokenFileURL": "gs://avf-credentials/covid19-text-it-token.txt",
+      "ActivationFlowNames": [
+
+      ],
+      "SurveyFlowNames": [
+        "covid19_s01_demog"
+      ],
+      "TestContactUUIDs": [
+        "59fff919-ffe6-4baa-a674-c1a11b956445",
+        "0265fb3d-a139-4ed4-bb6d-7552e5be5e59"
+      ]
+    },
+    {
+      "SourceType": "RapidPro",
+      "Domain": "textit.in",
+      "TokenFileURL": "gs://avf-credentials/unicef-kenya-textit-token.txt",
+      "ActivationFlowNames": [
+
+      ],
+      "SurveyFlowNames": [
+        "unicef_covid19_ke_s01_demog"
+      ],
+      "TestContactUUIDs": [
+        "94075043-57c6-43c7-8b89-880478ccad8e",
+        "0e56c4f8-8714-49c0-8d1f-a5a75c21b1c9"
+      ]
+    },
+    {
+      "SourceType": "RapidPro",
+      "Domain": "textit.in",
+      "TokenFileURL": "gs://avf-credentials/oxfam-kenya-textit-token.txt",
+      "ActivationFlowNames": [
+
+      ],
+      "SurveyFlowNames": [
+        "oxfam_wash_s01_demog"
+      ],
+      "TestContactUUIDs": [
+        "94075043-57c6-43c7-8b89-880478ccad8e",
+        "0e56c4f8-8714-49c0-8d1f-a5a75c21b1c9"
+      ]
+    },
+    {
+      "SourceType": "RapidPro",
+      "Domain": "textit.in",
+      "TokenFileURL": "gs://avf-credentials/world-vision-textit-token.txt",
+      "ContactsFileName": "contacts",
+      "ActivationFlowNames": [
+
+      ],
+      "SurveyFlowNames": [
+        "worldvision_s01_demog"
+      ],
+      "TestContactUUIDs": [
+        "3c2d94f4-3833-4828-a577-cd6c082135df",
+        "015c8230-23b3-4207-b961-ebcc7acc1da9",
+        "9ba615c1-5939-4b16-9092-829597419134"
+      ]
     }
   ],
   "ListeningGroupCSVURLs": [],
@@ -36,7 +115,51 @@
 
     {"RapidProKey": "Vaccination_Thoughts_Catchall (Text) - ke_vax_activation", "PipelineKey": "other_messages_raw", "IsActivationMessage": true},
     {"RapidProKey": "Vaccination_Thoughts_Catchall (Run ID) - ke_vax_activation", "PipelineKey": "other_messages_run_id"},
-    {"RapidProKey": "Vaccination_Thoughts_Catchall (Time) - ke_vax_activation", "PipelineKey": "sent_on"}
+    {"RapidProKey": "Vaccination_Thoughts_Catchall (Time) - ke_vax_activation", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "Constituency (Text) - covid19_s01_demog", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Constituency (Time) - covid19_s01_demog", "PipelineKey": "location_time"},
+    {"RapidProKey": "Gender (Text) - covid19_s01_demog", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Gender (Time) - covid19_s01_demog", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Text) - covid19_s01_demog", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Age (Time) - covid19_s01_demog", "PipelineKey": "age_time"},
+
+    {"RapidProKey": "Constituency (Text) - covid19_ke_urban_s01_demog", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Constituency (Time) - covid19_ke_urban_s01_demog", "PipelineKey": "location_time"},
+    {"RapidProKey": "Gender (Text) - covid19_ke_urban_s01_demog", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Gender (Time) - covid19_ke_urban_s01_demog", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Text) - covid19_ke_urban_s01_demog", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Age (Time) - covid19_ke_urban_s01_demog", "PipelineKey": "age_time"},
+
+    {"RapidProKey": "Constituency (Text) - undp_kenya_s01_demog", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Constituency (Time) - undp_kenya_s01_demog", "PipelineKey": "location_time"},
+    {"RapidProKey": "Gender (Text) - undp_kenya_s01_demog", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Gender (Time) - undp_kenya_s01_demog", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Text) - undp_kenya_s01_demog", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Age (Time) - undp_kenya_s01_demog", "PipelineKey": "age_time"},
+
+    {"RapidProKey": "Constituency (Text) - unicef_covid19_ke_s01_demog", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Constituency (Time) - unicef_covid19_ke_s01_demog", "PipelineKey": "location_time"},
+    {"RapidProKey": "Gender (Text) - unicef_covid19_ke_s01_demog", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Gender (Time) - unicef_covid19_ke_s01_demog", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Text) - unicef_covid19_ke_s01_demog", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Age (Time) - unicef_covid19_ke_s01_demog", "PipelineKey": "age_time"},
+
+    {"RapidProKey": "Constituency (Text) - oxfam_wash_s01_demog", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Constituency (Time) - oxfam_wash_s01_demog", "PipelineKey": "location_time"},
+    {"RapidProKey": "Gender (Text) - oxfam_wash_s01_demog", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Gender (Time) - oxfam_wash_s01_demog", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Text) - oxfam_wash_s01_demog", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Age (Time) - oxfam_wash_s01_demog", "PipelineKey": "age_time"},
+    {"RapidProKey": "Disabled (Text) - oxfam_wash_s01_demog", "PipelineKey": "disabled_raw"},
+    {"RapidProKey": "Disabled (Time) - oxfam_wash_s01_demog", "PipelineKey": "disabled_time"},
+
+    {"RapidProKey": "Constituency (Text) - worldvision_s01_demog", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Constituency (Time) - worldvision_s01_demog", "PipelineKey": "location_time"},
+    {"RapidProKey": "Gender (Text) - worldvision_s01_demog", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Gender (Time) - worldvision_s01_demog", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Text) - worldvision_s01_demog", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Age (Time) - worldvision_s01_demog", "PipelineKey": "age_time"}
   ],
   "ProjectStartDate": "2021-03-18T00:00:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/configurations/pipeline_config.json
+++ b/configurations/pipeline_config.json
@@ -164,7 +164,7 @@
   "ProjectStartDate": "2021-03-18T00:00:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",
   "FilterTestMessages": true,
-  "MoveWSMessages": false,
+  "MoveWSMessages": true,
   "AutomatedAnalysis": {
     "GenerateCountyThemeDistributionMaps": true,
     "GenerateConstituencyThemeDistributionMaps": true

--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -16,7 +16,12 @@ DATA_ROOT=$3
 
 DATASETS=(
     "KE_VAX_vaccination_thoughts"
-    "KE_VAX_other_thoughts"
+    "KE_VAX_other_messages"
+
+    "Kenya_Pool_age"
+    "Kenya_Pool_gender"
+    "Kenya_Pool_location"
+    "Kenya_Pool_disabled"
 )
 
 cd "$CODA_V2_ROOT/data_tools"

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -16,7 +16,12 @@ DATA_ROOT=$3
 
 DATASETS=(
     "KE_VAX_vaccination_thoughts"
-    "KE_VAX_other_thoughts"
+    "KE_VAX_other_messages"
+
+    "Kenya_Pool_age"
+    "Kenya_Pool_gender"
+    "Kenya_Pool_location"
+    "Kenya_Pool_disabled"
 )
 
 cd "$CODA_V2_ROOT/data_tools"


### PR DESCRIPTION
This is a little complicated. The strategy here is to:
- Download demographics from the UNDP-Kenya (covid19), UNICEF-COVID19-KE, OXFAM-WASH, and WorldVision TextIt workspaces and link them to participants as usual.
- Download the various demog datasets from Coda, patch them together using combine_coda_datasets.py, and upload these to unified Kenya_Pool datasets in Coda. You can check how this looks in production Coda.
- Add all the standard configuration for demogs.