### PR TITLE
Make gratitude a normal code instead of greeting

### DIFF
--- a/code_schemes/other_messages.json
+++ b/code_schemes/other_messages.json
@@ -148,12 +148,12 @@
       "VisibleInCoda": true
     },
     {
-      "CodeID": "code-c1bf9e3b",
+      "CodeID": "code-22da3bf4",
       "CodeType": "Normal",
-      "MetaCode": "greeting",
-      "DisplayText": "greeting",
+      "MetaCode": "gratitude",
+      "DisplayText": "gratitude",
       "NumericValue": 19,
-      "StringValue": "greeting",
+      "StringValue": "gratitude",
       "VisibleInCoda": true
     },
     {
@@ -247,6 +247,15 @@
       "VisibleInCoda": true
     },
     {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-OI-c5f1d054",
       "CodeType": "Meta",
       "MetaCode": "opt-in",
@@ -289,15 +298,6 @@
       "DisplayText": "meta: other",
       "NumericValue": -100110,
       "StringValue": "other",
-      "VisibleInCoda": true
-    },
-    {
-      "CodeID": "code-GR-e6de1b7e",
-      "CodeType": "Meta",
-      "MetaCode": "gratitude",
-      "DisplayText": "meta: gratitude",
-      "NumericValue": -100100,
-      "StringValue": "gratitude",
       "VisibleInCoda": true
     },
     {


### PR DESCRIPTION
#6 promoted meta code greeting to be a normal code. This was a mistake, it should actually have been gratitude that got promoted.